### PR TITLE
Update Frontegg AdminPortal to 3.11.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "^1.3.0",
-    "@frontegg/redux-store": "^2.7.0",
+    "@frontegg/admin-portal": "3.11.0",
+    "@frontegg/redux-store": "3.11.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,6 +970,14 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@frontegg/admin-portal@3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.11.0.tgz#21cde4848293bf702f0ddaa577e7cbe35117c539"
+  integrity sha512-IkH7N49EB8ZtGT6A5ZpPq3ovPJ+PFdHKeg14LgISiOVzfvgHqLFs7kseJAX7KzxOWad8ry2ti3nYRs3Xz6YAmg==
+  dependencies:
+    "@frontegg/injector" "0.0.26"
+    uuid "^8.3.0"
+
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-0.5.2.tgz#a53a231e000855e9a58dbd44113154a383ad7eda"
@@ -977,18 +985,10 @@
   dependencies:
     "@frontegg/injector" "^0.0.23"
 
-"@frontegg/admin-portal@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-1.3.1.tgz#437ec29339652217603a9801cb424c872417a66e"
-  integrity sha512-DWsHDTURCTAnWte5kfc3VWE8ZxG8kqUhMInvuAQCeJkGjFU3EHpBfrRMXme+dngo0yPWeUF+WjNxrV8M1czZMQ==
-  dependencies:
-    "@frontegg/injector" "0.0.25"
-    uuid "^8.3.0"
-
-"@frontegg/injector@0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.25.tgz#05009e41f8f1790941fa907c97c67b0496ddbf00"
-  integrity sha512-NXbn9gCD6hopsPGQzBnfxI2qEFqiqTSuqop6tm/1fu6jgWWxhRu9+rX3VRoGDYqWgeuypgLN67EtWcG0LLDnKQ==
+"@frontegg/injector@0.0.26":
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.26.tgz#771c96da1f930d732d5d286ed1067697c7e239eb"
+  integrity sha512-Y0a2QKihNi7l4jdT5mez7ecIEZCaKW5ga+RzpD5JvrpX5N6ZM7bsSCaKoyAXJgMdU1mWy/2ZNjp9vY8Z2OQdKA==
 
 "@frontegg/injector@^0.0.23":
   version "0.0.23"
@@ -1004,24 +1004,28 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@^2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-2.7.0.tgz#acf4750844ab5734aaa2423eeff3e16ca686bc20"
-  integrity sha512-I+J9SGr/lTGrH2m6fhI7JUzH5eocEZTUTL4S2DUk1HTV0MMXaLGrnRSe/le7zeJmV1+GjtokRQMkeoIk44Y53w==
+"@frontegg/redux-store@3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.11.0.tgz#2df73a7edbedb84d19af6f1a5a805bcf0cdeb168"
+  integrity sha512-lf3VV0V+btT0md/flaif6RD3e+ynLAYy/kWVQyms3F8g4iCMZv+yc7oJ4lTqef/c4ssNkHgoHglpjXpUO4T7AA==
   dependencies:
-    "@frontegg/rest-api" "^2.7.0"
+    "@frontegg/rest-api" "^2.10.14"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
+    tslib "^2.1.0"
+    uuid "^8.3.0"
 
 "@frontegg/rest-api@1.23.40":
   version "1.23.40"
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-1.23.40.tgz#ffbeb6097ac7b053073abcf84fc144cd5efadccc"
   integrity sha512-T08RWX2bv7fN6ax3xEguz6rrnbsnrVUhDcZhE2ij11rzo/VVw9QJ/A4l0RbyBuKDGJte6XjFbOip6w9R++reww==
 
-"@frontegg/rest-api@^2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.7.0.tgz#715fa3bf20cd43489554773d990247a338712f44"
-  integrity sha512-BV6mAyfuBSaUTSlQoIQn8MD7/8sZ6sVtRiFU4yM/SPuZ0NoSxYhWyvsarAkvKvqE6ABSIuQkmATYgvfKyE/TOg==
+"@frontegg/rest-api@^2.10.14":
+  version "2.10.15"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.15.tgz#c98edfff16cdb8d414ac86de3ca076914fd64e08"
+  integrity sha512-t89wuTIhCW/XpLv7WweHmU8JGrov0DD+y/SribSL2ZEK1JojhhTfTLMGZh3MLM0/eHDS36l4nGjCaa8L+L/qFQ==
+  dependencies:
+    tslib "^2.3.0"
 
 "@frontegg/vue-ui@^0.1.0":
   version "0.1.3"
@@ -11728,6 +11732,11 @@ tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0, tslib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslint@^5.20.1:
   version "5.20.1"


### PR DESCRIPTION
### AdminPortal 3.11.0:
- v3.11.0
- FR-3140 - Add trigger vue pipeline on AdminPortal release
- FR-3649 - make sure to load navigation bar only after loading the relevant policy
- FR-3804 - remove last triggered column from webhooks table
- FR-3722 - Subscription Cancel
-  Conflicts:
- store/package.json
- store/src/subscriptions/Billing/Information/saga.ts
- 	yarn.lock
- FR-3643 - Login flow oidc
- FR-3794 - custom link in login
- FR-3806 - update content for webhooks page
- FR-3814 - oidc configuration fixes
- 	packages/ui/src/pages/SubscriptionPage/Checkout/Stripe/StripeSubscriptionCheckoutForm.tsx
- 	packages/ui/src/pages/SubscriptionPage/SubscriptionPage.tsx