### PR TITLE
Update Frontegg AdminPortal to 3.13.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.12.0",
-    "@frontegg/redux-store": "3.12.0",
+    "@frontegg/admin-portal": "3.13.0",
+    "@frontegg/redux-store": "3.13.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,10 +970,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@3.12.0":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.12.0.tgz#a839e78fc4e50af5380a0d48802f1913e3e95d37"
-  integrity sha512-JstsFyYuWqVP9lGqqij3b4qwBUuZ+1NtGEvsK+E1uk0Or24lv+NNjahbK8SY3nVtvbG+G/Wf3flUW4OOodVrgw==
+"@frontegg/admin-portal@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.13.0.tgz#4742dcb5716292f8ba3b6882b2da5cfc44914fa0"
+  integrity sha512-5iHU20WVSDgYIvbQ0OuGtsDrAc3gaKXRZiVm3R+9Ba7nhqBLgoL4A9/5D2jcXgUxsAxMGnow0AcGAoVnmtvQUQ==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -1004,12 +1004,12 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@3.12.0":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.12.0.tgz#7d70f9c4221344b6e5ab6aa928aaf7cfae723838"
-  integrity sha512-rEQYblz7FBr5EKj4uXZgOicRYr0ZzgWKy63HwgXC8uel//YQn4fgkxCTGJ7MISGWCWmZaCJ9FEr+VHLaPKqRRg==
+"@frontegg/redux-store@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.13.0.tgz#08e0a98bc4d6535933be40df98b7dd3a7596aced"
+  integrity sha512-BG8r5Y5W9IRW8fTluGmTdqq/la/HucHLYpar7QnD1wf36TMHFC9SzfII/uSBirfTcUS5cEZWlHHfVN23HP2/AQ==
   dependencies:
-    "@frontegg/rest-api" "^2.10.14"
+    "@frontegg/rest-api" "^2.10.15"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.1.0"
@@ -1020,7 +1020,7 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-1.23.40.tgz#ffbeb6097ac7b053073abcf84fc144cd5efadccc"
   integrity sha512-T08RWX2bv7fN6ax3xEguz6rrnbsnrVUhDcZhE2ij11rzo/VVw9QJ/A4l0RbyBuKDGJte6XjFbOip6w9R++reww==
 
-"@frontegg/rest-api@^2.10.14":
+"@frontegg/rest-api@^2.10.15":
   version "2.10.15"
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.15.tgz#c98edfff16cdb8d414ac86de3ca076914fd64e08"
   integrity sha512-t89wuTIhCW/XpLv7WweHmU8JGrov0DD+y/SribSL2ZEK1JojhhTfTLMGZh3MLM0/eHDS36l4nGjCaa8L+L/qFQ==


### PR DESCRIPTION
### AdminPortal 3.13.0:
- v3.13.0
- Fix admin box loading
- FR-3651 Connectivity is sending ~300 fetch requests for slack configuration
- FR-3846 - custom input error
- FR-3863 - cannot add public key manually
- FR-3548 - add externally managed screen, refactor code

### AdminPortal 3.12.0:
- v3.12.0
- FR-3599 - FR-3600 - Dynmic html component
- FR-3848 - Add option to save query param after auth redirect