### PR TITLE
Update Frontegg AdminPortal to 3.15.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.1",
-    "@frontegg/redux-store": "3.14.1",
+    "@frontegg/admin-portal": "3.15.0",
+    "@frontegg/redux-store": "3.15.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.13.0",
-    "@frontegg/redux-store": "3.13.0",
+    "@frontegg/admin-portal": "3.14.0",
+    "@frontegg/redux-store": "3.14.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.0",
-    "@frontegg/redux-store": "3.14.0",
+    "@frontegg/admin-portal": "3.14.1",
+    "@frontegg/redux-store": "3.14.1",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,10 +970,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.13.0.tgz#4742dcb5716292f8ba3b6882b2da5cfc44914fa0"
-  integrity sha512-5iHU20WVSDgYIvbQ0OuGtsDrAc3gaKXRZiVm3R+9Ba7nhqBLgoL4A9/5D2jcXgUxsAxMGnow0AcGAoVnmtvQUQ==
+"@frontegg/admin-portal@3.14.0":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.14.0.tgz#391508227cefeeaf1e4d03541a47af06e64eefd3"
+  integrity sha512-V6wLVoJWcaskniPD5GXmaTf6du/cm2xwcUJ4si5kOOHnpFg9SI8I3gnOzhmQ2zwpZZyfYKcBu5FXQoZaZ8K3+Q==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -1004,10 +1004,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@3.13.0":
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.13.0.tgz#08e0a98bc4d6535933be40df98b7dd3a7596aced"
-  integrity sha512-BG8r5Y5W9IRW8fTluGmTdqq/la/HucHLYpar7QnD1wf36TMHFC9SzfII/uSBirfTcUS5cEZWlHHfVN23HP2/AQ==
+"@frontegg/redux-store@3.14.0":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.14.0.tgz#517fed212824b00416dcffdde6d836e59b5cf809"
+  integrity sha512-C6CCCbtO0Mv6fxj7k4Mj3gt8YCwajl5BHSslqfXaVM3w8OueOG8/D3D3jS6A67ZHPPji9Z1YCkfghRFZJXv8Rw==
   dependencies:
     "@frontegg/rest-api" "^2.10.15"
     "@reduxjs/toolkit" "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,10 +970,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.14.0.tgz#391508227cefeeaf1e4d03541a47af06e64eefd3"
-  integrity sha512-V6wLVoJWcaskniPD5GXmaTf6du/cm2xwcUJ4si5kOOHnpFg9SI8I3gnOzhmQ2zwpZZyfYKcBu5FXQoZaZ8K3+Q==
+"@frontegg/admin-portal@3.14.1":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.14.1.tgz#01c7a579bca0eee9d8cae4ed0903c73bb2499f94"
+  integrity sha512-atz7kvFovhgKSXatGfvNXUFe4i0+/hTwNNe5l2mWtz1OX/NQJDZRg32oseGnZMVzYeNcpmGQnUoLI7Dz/xZzqQ==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -1004,10 +1004,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.14.0.tgz#517fed212824b00416dcffdde6d836e59b5cf809"
-  integrity sha512-C6CCCbtO0Mv6fxj7k4Mj3gt8YCwajl5BHSslqfXaVM3w8OueOG8/D3D3jS6A67ZHPPji9Z1YCkfghRFZJXv8Rw==
+"@frontegg/redux-store@3.14.1":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.14.1.tgz#ed7698c6b708ead78295eff0ec33f8a9f6b2fa0c"
+  integrity sha512-eYT9NK8ehxEDfHnzbunUUj4xROTu4Yxcx3d7Sg+Y1z7mBwxiTRTzjb9WCe1ZQTZMEuVGQiOKg9ACcwh5mpSk/g==
   dependencies:
     "@frontegg/rest-api" "^2.10.15"
     "@reduxjs/toolkit" "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,10 +970,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@3.14.1":
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.14.1.tgz#01c7a579bca0eee9d8cae4ed0903c73bb2499f94"
-  integrity sha512-atz7kvFovhgKSXatGfvNXUFe4i0+/hTwNNe5l2mWtz1OX/NQJDZRg32oseGnZMVzYeNcpmGQnUoLI7Dz/xZzqQ==
+"@frontegg/admin-portal@3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.15.0.tgz#a8a133a7132853cfda4b32c85ce3a00120fb217b"
+  integrity sha512-jd32RFn+KmcCVXalAZSkEULAvM4cUlUsAX4Iv7rgtv5bcm/EbXa5BK+kSwM7MM3ZMWTKtVTFNkrNzPB6+kf1dQ==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -1004,10 +1004,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@3.14.1":
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.14.1.tgz#ed7698c6b708ead78295eff0ec33f8a9f6b2fa0c"
-  integrity sha512-eYT9NK8ehxEDfHnzbunUUj4xROTu4Yxcx3d7Sg+Y1z7mBwxiTRTzjb9WCe1ZQTZMEuVGQiOKg9ACcwh5mpSk/g==
+"@frontegg/redux-store@3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.15.0.tgz#7a3d0c0cf65ca267204f1f5a77aaf3a01f754bb7"
+  integrity sha512-c4t3lHJGDqUe6a4jZlcjFROdkSXpw2OkPdL2iCfZajKW2wt3qVInSYNRp/3OXBL9FmNgdjAVzGhivlDP9DADCw==
   dependencies:
     "@frontegg/rest-api" "^2.10.15"
     "@reduxjs/toolkit" "^1.5.0"


### PR DESCRIPTION
### AdminPortal 3.15.0:
- v3.15.0
- FR-3814 - fix configuration
- FR-3944 - remove logs and added custom loader to a condition in injector
- FR-3987 - fix social layout

### AdminPortal 3.14.1:
- v3.14.1
- FR-3944 - Added custom loader as an option to refetch request authorize
- FR-3981 - when choose other  saml vendor then reset saml config to manual
- id for admin box x
- FR-3889 - support permissions in admin box
- FR-3793 - add login box customizion
- FR-3596 - custom social login icon

### AdminPortal 3.14.0:
- v3.14.0
- FR-3944 - added logs tp debug in prod
- FR-3795 - custom text to signUp switch