### PR TITLE
Update Frontegg AdminPortal to 3.17.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.16.0",
-    "@frontegg/redux-store": "3.16.0",
+    "@frontegg/admin-portal": "3.17.0",
+    "@frontegg/redux-store": "3.17.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,10 +970,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@3.16.0":
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.16.0.tgz#a3bf89f6a306e8071a75e6f0e65248396069e017"
-  integrity sha512-onNRoraBVNXuVDG4qI19pJUWlV0oWxDPd3/jnxm5bud/sdrdFyFz/VSHLhHK4vNIsvQPO1+qa/G5A2qXemRlxA==
+"@frontegg/admin-portal@3.17.0":
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.17.0.tgz#530af365d48e3e211b1dfd63b971eaf39d0b2dcb"
+  integrity sha512-x4TANu1kges3lCfMk5sHwneLLq2FcCxdvcIIOcc8Lhwcvu94dmyF0PDTyHxpPhgn3/J8Z5zy0BgJFKNWCXohjg==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -1004,12 +1004,12 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@3.16.0":
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.16.0.tgz#fd8e0e0cec801858d88eaa585289ad5e85a6af14"
-  integrity sha512-lG7KCve83XfGRi/Y6Y1AMNgCpIOi/wZ40yNbvr8H0qxnbzT5Blmf6FfTJhHBeEF0e3Pecx4BUiQmaYS8ATROUg==
+"@frontegg/redux-store@3.17.0":
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.17.0.tgz#c93f886378669d755f2c2c15dce5891e0d2ea806"
+  integrity sha512-stLy1HjZvjB6aziJivayBZnsmYzS+t4aeFAvvlFqsUKRRyRkUIjzzTaFtPMmJyfS4gzqYLegT8HS0e0sqtkcrg==
   dependencies:
-    "@frontegg/rest-api" "^2.10.17"
+    "@frontegg/rest-api" "^2.10.19"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.1.0"
@@ -1020,10 +1020,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-1.23.40.tgz#ffbeb6097ac7b053073abcf84fc144cd5efadccc"
   integrity sha512-T08RWX2bv7fN6ax3xEguz6rrnbsnrVUhDcZhE2ij11rzo/VVw9QJ/A4l0RbyBuKDGJte6XjFbOip6w9R++reww==
 
-"@frontegg/rest-api@^2.10.17":
-  version "2.10.17"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.17.tgz#24c49391c7f6b68faf11cdcba21b95758c6d03ef"
-  integrity sha512-1e+VS34yP3YH81z3m7QLBzQwTTtQRX7dUiZ2BqtGokBJUYTSTKIpfHnHVj998frkyE6pQvkGBDNbmaycPin2gw==
+"@frontegg/rest-api@^2.10.19":
+  version "2.10.19"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.19.tgz#7adba708414ff9210bdb215c2e2594cec4399ab9"
+  integrity sha512-HorhSDROvDC/18RKiDcNXn8XbbMJQswOVXMXe2Y8eLZ2TEJVooq0luXonsqogArRUyPu0U6nhyYl2s+lexi4JA==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
### AdminPortal 3.17.0:
- v3.17.0
- FR-3965 - login box magic link flow
- id for sso box
- FR-3961 - cant see acs url and entity id
- FR-3893 - add default value to palette and typography in Inner provider