### PR TITLE
Update Frontegg AdminPortal to 4.21.2

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.21.1",
-    "@frontegg/redux-store": "4.21.1",
+    "@frontegg/admin-portal": "4.21.2",
+    "@frontegg/redux-store": "4.21.2",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,13 +970,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.21.1.tgz#c1e66b02d8120332ce4b49f0b23da13010776ec5"
-  integrity sha512-LnHLCmX8MXUpDzGx9Y8ahEoWjFuCJObhx5XmChGphy4+McWkX8ws4OVV2x3nIUo/aOrX1E57DTRzshQSpizRaQ==
+"@frontegg/admin-portal@4.21.2":
+  version "4.21.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.21.2.tgz#52be0c83630837f9d00ef02e0e4a8a45f9510a77"
+  integrity sha512-2vuGOHuEryexV7jB/as2byfCrDGTkUfz37Jf8bvHjbKW1hr0QLSOaYwRWr24hydmk88/4p4mjdJCc+BDJTzXtg==
   dependencies:
-    "@frontegg/redux-store" "4.21.1"
-    "@frontegg/types" "4.21.1"
+    "@frontegg/redux-store" "4.21.2"
+    "@frontegg/types" "4.21.2"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -999,10 +999,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.21.1.tgz#586a616753d3a860116baedfb5b47126d2501084"
-  integrity sha512-68bKbeWWG3A0Wv1KMlSp1C7vX7hQXVIDrnoiyzNOJaZkfuTKz+NpMQTP8ShyUfN0NdthMEUCj03Fj5+z1R8dqw==
+"@frontegg/redux-store@4.21.2":
+  version "4.21.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.21.2.tgz#9fd60b8bad1ff657771bbbe76922d7da26b88b15"
+  integrity sha512-ZNxoVkRpg4TuUMMPqCq4unnhSsqI1LDlkrgu/E7QVzEKr5y5+sn2wtAP0HTNqmmjgjtFhkalMPKJZwgPEIDdIw==
   dependencies:
     "@frontegg/rest-api" "^2.10.30"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1022,10 +1022,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.21.1":
-  version "4.21.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.21.1.tgz#ea04cf5ae58a6bfe96736ddadcb0a7c4e0390491"
-  integrity sha512-+CBLsWAvGNV3+Tw7sh6m2hs5i6QdUbSfDaMIFsR4fedBkHhPHqL+4a96XIbVW8a758MPLnqHNc/te6os6v88JA==
+"@frontegg/types@4.21.2":
+  version "4.21.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.21.2.tgz#63faf0189cf7d6a66d8a6d2d884c76e0bbafd556"
+  integrity sha512-O9MK9gCY19MTb7gUELoOl38gT8xglBNvgsWPWV9eg47s5lJGmZ9btnyPKNta6XXah3YRYNM/TAHyLT8pj5FuhA==
   dependencies:
     csstype "^3.0.8"
 


### PR DESCRIPTION
### AdminPortal 4.21.2:
- [FR-4339](https://frontegg.atlassian.net/browse/FR-4339) - fix dynamic component - [bd1e5d54](https://github.com/frontegg/admin-box/pulls?q=bd1e5d54)
- [FR-4297](https://frontegg.atlassian.net/browse/FR-4297) - Subscription permissions - [40f635da](https://github.com/frontegg/admin-box/pulls?q=40f635da)
- [FR-3677](https://frontegg.atlassian.net/browse/FR-3677) - add activate account link expired component to login box - [6018b8b9](https://github.com/frontegg/admin-box/pulls?q=6018b8b9)
- [FR-4331](https://frontegg.atlassian.net/browse/FR-4331) - remove company name - [c75e8151](https://github.com/frontegg/admin-box/pulls?q=c75e8151)