### PR TITLE
Update Frontegg AdminPortal to 4.23.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.22.0",
-    "@frontegg/redux-store": "4.22.0",
+    "@frontegg/admin-portal": "4.23.0",
+    "@frontegg/redux-store": "4.23.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,13 +970,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.22.0.tgz#000a8fa94715454d995cab5adcf60584ff19d27a"
-  integrity sha512-xjxfnD7Et9/Dk0/TrCQiGLF2OwPqOi+zJTMx8AKcqWgYEw0SyI29YUhpswIPlkay8NI1qPQ3xYMcxXISkPGwSQ==
+"@frontegg/admin-portal@4.23.0":
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.23.0.tgz#34c4a1602a06bc49bc0d534c3a4f5dd9471dfa5d"
+  integrity sha512-NskvOZjfBvvfyUH8T3i/++phSBuawlC8sYgqBp1r3dIw19FbeG0QniSo+GZveAAFB00AXG/iPMnWNcCfqSSR+Q==
   dependencies:
-    "@frontegg/redux-store" "4.22.0"
-    "@frontegg/types" "4.22.0"
+    "@frontegg/redux-store" "4.23.0"
+    "@frontegg/types" "4.23.0"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -999,10 +999,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.22.0.tgz#8b1b2296ce6ea397f6854bd8ebf6987621bc3fc3"
-  integrity sha512-7ZupD0pa+l6BBrmlotQCdHrl7UgTCCUxo/tsUNiyUj7uJkL8GAkA/yT0pxwv0jVKfDQhkN55dmKlUgNjO+ThnA==
+"@frontegg/redux-store@4.23.0":
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.23.0.tgz#31947f085d7d2252f266c3d6418cce55fe6b46a3"
+  integrity sha512-YE0jgerKLoSUEqmCUSqFGojHZswNeBinp6ZZ4ujwQuy5qd/AcLAwEJmIMIjgGUQA9NZ0UfQLJsoTICN0LfgY8A==
   dependencies:
     "@frontegg/rest-api" "^2.10.30"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1022,10 +1022,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.22.0.tgz#b7d04dd95ae8cc11e2f205e4da9435836b2326f1"
-  integrity sha512-ESpJjKdfLUHUGZJViyXPAGY5nQNIPa4SBKP0GBHQkKWs+TzMEsMiduR2pw0V0QUHFRjaGxQRelWaiwLeoKRuEA==
+"@frontegg/types@4.23.0":
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.23.0.tgz#787fff90c9f7f28af4649c181cc321db09ac19e0"
+  integrity sha512-LQE1LFyuM96UmdPgQCFFbpYVU+nIq5nRLoncvqmlIqw91v7sigl5ZWCVlpW5oxcWjbPmnirJLc2rr12yyDROCg==
   dependencies:
     csstype "^3.0.8"
 


### PR DESCRIPTION
### AdminPortal 4.23.0:
- [FR-4354](https://frontegg.atlassian.net/browse/FR-4354) - Revert dynamic import to enable i18 - [d080206c](https://github.com/frontegg/admin-box/pulls?q=d080206c)