### PR TITLE
Update Frontegg AdminPortal to 4.39.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.37.0",
-    "@frontegg/redux-store": "4.37.0",
+    "@frontegg/admin-portal": "4.38.0",
+    "@frontegg/redux-store": "4.38.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.38.0",
-    "@frontegg/redux-store": "4.38.0",
+    "@frontegg/admin-portal": "4.39.0",
+    "@frontegg/redux-store": "4.39.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.36.2",
-    "@frontegg/redux-store": "4.36.2",
+    "@frontegg/admin-portal": "4.37.0",
+    "@frontegg/redux-store": "4.37.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.38.0":
-  version "4.38.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.38.0.tgz#0acb6f7ded271d91bae62a0c9e21bc9a2427b0e9"
-  integrity sha512-xgTsskOC5BKo84woqrwB/UxOvNeks0z2T9oMUFJ2OFyM/Ew7CBFgX13GQC4TE+8Zru8EECD32A2Pb6ABf3Lg0A==
+"@frontegg/admin-portal@4.39.0":
+  version "4.39.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.39.0.tgz#6e01557956850a90b63689c077d0202d9168beb7"
+  integrity sha512-lmva2Q5xagNg218JvS8atcMHU6/Ece2v9vSbs69dmG289OYEAGL/0+V2XC4tkEZ5B5r696iz3pV9KmwyYFvOZw==
   dependencies:
-    "@frontegg/react-hooks" "4.38.0"
-    "@frontegg/types" "4.38.0"
+    "@frontegg/react-hooks" "4.39.0"
+    "@frontegg/types" "4.39.0"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -997,12 +997,12 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.23.tgz#d4fca57659c6b5fec913b801f0196a8c8e77512f"
   integrity sha512-aZNZCIHuZwPpkPkXTmBpJS3Ot8ID00vMuN8z1YGCvBKHzA6PhaitJV6ZxAUQweUG7suv872iNdNJFr85ObPOLg==
 
-"@frontegg/react-hooks@4.38.0":
-  version "4.38.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.38.0.tgz#445ec9028d58752901c9ab62f7a2a42f6af9ba9d"
-  integrity sha512-KRptl6HTP+fVrBXx9Y15ZNcRWOI6UnQkYp3iYPX3upZiZSpHLTaWYlbtLKrCSn/deBCjyLZNjbY/SlmAN98aHg==
+"@frontegg/react-hooks@4.39.0":
+  version "4.39.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.39.0.tgz#2ce42647c8a3cadc815b49fcb4839fd49cdb171e"
+  integrity sha512-Lpyq0tY4mjbNS1Q06zMP3ZdKxxhdX0RbxpMy00G19wmWZUw9v/g3znORGeXRoBfGr/T9bGdu8SrChVIQKH77Cg==
   dependencies:
-    "@frontegg/redux-store" "4.38.0"
+    "@frontegg/redux-store" "4.39.0"
     react-redux "^7.x"
 
 "@frontegg/redux-store@1.23.40":
@@ -1014,12 +1014,12 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.38.0":
-  version "4.38.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.38.0.tgz#f99a39af1aac1ea0f61d183b1c58061b74e228ac"
-  integrity sha512-k+gEukjCcr6O5VH5ts59FzQICynJin4zUA6ZEpOzC9iJKX1uTiIhzeFpXsfjNIKDYHmKL1VmS1sYkZxe4//G3w==
+"@frontegg/redux-store@4.39.0":
+  version "4.39.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.39.0.tgz#891b93e04491d6bb84ddb2c5d1522ab1f137638a"
+  integrity sha512-vaPFfh2cORTODgvBU/NqvAW9bBuoUqi/FOXyxgrolelARvvEkmudM4+iFtixcBa5TtPlbnGQgrX8PIHXYdksaw==
   dependencies:
-    "@frontegg/rest-api" "2.10.45"
+    "@frontegg/rest-api" "2.10.46"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
@@ -1030,15 +1030,15 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-1.23.40.tgz#ffbeb6097ac7b053073abcf84fc144cd5efadccc"
   integrity sha512-T08RWX2bv7fN6ax3xEguz6rrnbsnrVUhDcZhE2ij11rzo/VVw9QJ/A4l0RbyBuKDGJte6XjFbOip6w9R++reww==
 
-"@frontegg/rest-api@2.10.45":
-  version "2.10.45"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.45.tgz#f4d63ca6d10d238bfb4bdb908dce2aab0d13bb09"
-  integrity sha512-2Z5zGlZVL85Mg9Psi+d44Lrrl25fyTS89aAVD0/SRDBIpl8ebHIDD0w7d5BmqspB7y0l60ndwF6TnBhk2vusMw==
+"@frontegg/rest-api@2.10.46":
+  version "2.10.46"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.46.tgz#47d59c385ff96927c5a6c0ae1baec8a01d479c83"
+  integrity sha512-YjQLnPZdH//Gb+b6FgLTDWSoBYFGZe9NqoTS3nuBNsQ+64LNtGH4OKUWU82/iByupPG3Uz7zOZAmxhYlKuEhaQ==
 
-"@frontegg/types@4.38.0":
-  version "4.38.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.38.0.tgz#06268d14a7d8698bb38f2ad5bc8bfb62c553fbe8"
-  integrity sha512-VeKQs34H8ntqy7v1k4LzTH/cscGlx34qwc9nmTHJoVwx65YDceUnM4VcWtw2t0Xv50aooY3nPYN/Mut8BRJ6uQ==
+"@frontegg/types@4.39.0":
+  version "4.39.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.39.0.tgz#99e4e0e6ff7a5b8de3391ef2b8e0790d0ea86532"
+  integrity sha512-SyjHqE7GWncyoJSuSJnsGPPWogvGjO1OpNbJe4nwreUNJ00dgsbdnwTSHr1MQ2Al4s/nnD+muzwjSaKxVAnIQQ==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.37.0.tgz#b704eca5db62d694283098537ea89d13e6309727"
-  integrity sha512-NawoZn9on35O8fkslZolRxSfeM3DXAuWuGS+loMkLiLbY2SJyqTtzCmtDIphD5A5ejxm8y1O9pGyA+zAkHIVaQ==
+"@frontegg/admin-portal@4.38.0":
+  version "4.38.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.38.0.tgz#0acb6f7ded271d91bae62a0c9e21bc9a2427b0e9"
+  integrity sha512-xgTsskOC5BKo84woqrwB/UxOvNeks0z2T9oMUFJ2OFyM/Ew7CBFgX13GQC4TE+8Zru8EECD32A2Pb6ABf3Lg0A==
   dependencies:
-    "@frontegg/react-hooks" "4.37.0"
-    "@frontegg/types" "4.37.0"
+    "@frontegg/react-hooks" "4.38.0"
+    "@frontegg/types" "4.38.0"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -997,12 +997,12 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.23.tgz#d4fca57659c6b5fec913b801f0196a8c8e77512f"
   integrity sha512-aZNZCIHuZwPpkPkXTmBpJS3Ot8ID00vMuN8z1YGCvBKHzA6PhaitJV6ZxAUQweUG7suv872iNdNJFr85ObPOLg==
 
-"@frontegg/react-hooks@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.37.0.tgz#e941b390d45252cb81b049950d07eb9327c2cf9c"
-  integrity sha512-ok2S5+doOfg0wDqD0d3IzBWWC6w/5L9WiVj3zPgCM6l6IetFYPeK9YzGpScSnPlODv1/GnaIzzA9QoegNeLiVw==
+"@frontegg/react-hooks@4.38.0":
+  version "4.38.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.38.0.tgz#445ec9028d58752901c9ab62f7a2a42f6af9ba9d"
+  integrity sha512-KRptl6HTP+fVrBXx9Y15ZNcRWOI6UnQkYp3iYPX3upZiZSpHLTaWYlbtLKrCSn/deBCjyLZNjbY/SlmAN98aHg==
   dependencies:
-    "@frontegg/redux-store" "4.37.0"
+    "@frontegg/redux-store" "4.38.0"
     react-redux "^7.x"
 
 "@frontegg/redux-store@1.23.40":
@@ -1014,10 +1014,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.37.0.tgz#fc038a28031793eda75060c0ad79ed15800e3a89"
-  integrity sha512-B2xPeakqvg9wZZ/wCSUiaBB7XJJF5MSi0Ebj4Q075qFYpHAUcHcDmiFXLpG/DwM6NIYS7r6tsJP9tfdyh3dyZQ==
+"@frontegg/redux-store@4.38.0":
+  version "4.38.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.38.0.tgz#f99a39af1aac1ea0f61d183b1c58061b74e228ac"
+  integrity sha512-k+gEukjCcr6O5VH5ts59FzQICynJin4zUA6ZEpOzC9iJKX1uTiIhzeFpXsfjNIKDYHmKL1VmS1sYkZxe4//G3w==
   dependencies:
     "@frontegg/rest-api" "2.10.45"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1035,10 +1035,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.45.tgz#f4d63ca6d10d238bfb4bdb908dce2aab0d13bb09"
   integrity sha512-2Z5zGlZVL85Mg9Psi+d44Lrrl25fyTS89aAVD0/SRDBIpl8ebHIDD0w7d5BmqspB7y0l60ndwF6TnBhk2vusMw==
 
-"@frontegg/types@4.37.0":
-  version "4.37.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.37.0.tgz#599c428cf7907485625693b38bb81689dc77f4a9"
-  integrity sha512-nvX1YcAwQWCx0EJBK5REGBzy/Tvc16IXS//vS556yeLdBKUSLuhSrJaSugV/rAvJjDJruBhhS4t2PdAICpppYA==
+"@frontegg/types@4.38.0":
+  version "4.38.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.38.0.tgz#06268d14a7d8698bb38f2ad5bc8bfb62c553fbe8"
+  integrity sha512-VeKQs34H8ntqy7v1k4LzTH/cscGlx34qwc9nmTHJoVwx65YDceUnM4VcWtw2t0Xv50aooY3nPYN/Mut8BRJ6uQ==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.36.2":
-  version "4.36.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.36.2.tgz#7e11a0fdd0044ad2f2df4d6a7591cda07ad1a8e0"
-  integrity sha512-ElecFrj5PoEnSG/2U/cvtR/x6XLe9WKUEPallTIXUzZ0Se+rMCehXyGw1v9Uv0gqxg6lLCqZC33/bzNVRcgHsQ==
+"@frontegg/admin-portal@4.37.0":
+  version "4.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.37.0.tgz#b704eca5db62d694283098537ea89d13e6309727"
+  integrity sha512-NawoZn9on35O8fkslZolRxSfeM3DXAuWuGS+loMkLiLbY2SJyqTtzCmtDIphD5A5ejxm8y1O9pGyA+zAkHIVaQ==
   dependencies:
-    "@frontegg/react-hooks" "4.36.2"
-    "@frontegg/types" "4.36.2"
+    "@frontegg/react-hooks" "4.37.0"
+    "@frontegg/types" "4.37.0"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -997,12 +997,12 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.23.tgz#d4fca57659c6b5fec913b801f0196a8c8e77512f"
   integrity sha512-aZNZCIHuZwPpkPkXTmBpJS3Ot8ID00vMuN8z1YGCvBKHzA6PhaitJV6ZxAUQweUG7suv872iNdNJFr85ObPOLg==
 
-"@frontegg/react-hooks@4.36.2":
-  version "4.36.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.36.2.tgz#0f57532b32fc4d29bd4e9c571c2516c531ac53c2"
-  integrity sha512-QZva79RSgul3r14b6mSDTbp0L4PgiBHMUFjjf5T2IFlgqKJnnmdaX6A5xEvHXsyaqv0qhDN8nxst7wpU4covwA==
+"@frontegg/react-hooks@4.37.0":
+  version "4.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.37.0.tgz#e941b390d45252cb81b049950d07eb9327c2cf9c"
+  integrity sha512-ok2S5+doOfg0wDqD0d3IzBWWC6w/5L9WiVj3zPgCM6l6IetFYPeK9YzGpScSnPlODv1/GnaIzzA9QoegNeLiVw==
   dependencies:
-    "@frontegg/redux-store" "4.36.2"
+    "@frontegg/redux-store" "4.37.0"
     react-redux "^7.x"
 
 "@frontegg/redux-store@1.23.40":
@@ -1014,12 +1014,12 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.36.2":
-  version "4.36.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.36.2.tgz#6fdbc0476acc3d6800d9b2f83856859dbb98df8f"
-  integrity sha512-yo1+miANSqJCWl1ds4rv3tV9DKIdbVKhRe1jAz2hlJNHv6+oDe9T0pkO1P7dlN1pzj5zVd7VLF5/GsfmvXcWyQ==
+"@frontegg/redux-store@4.37.0":
+  version "4.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.37.0.tgz#fc038a28031793eda75060c0ad79ed15800e3a89"
+  integrity sha512-B2xPeakqvg9wZZ/wCSUiaBB7XJJF5MSi0Ebj4Q075qFYpHAUcHcDmiFXLpG/DwM6NIYS7r6tsJP9tfdyh3dyZQ==
   dependencies:
-    "@frontegg/rest-api" "2.10.43"
+    "@frontegg/rest-api" "2.10.45"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
@@ -1030,15 +1030,15 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-1.23.40.tgz#ffbeb6097ac7b053073abcf84fc144cd5efadccc"
   integrity sha512-T08RWX2bv7fN6ax3xEguz6rrnbsnrVUhDcZhE2ij11rzo/VVw9QJ/A4l0RbyBuKDGJte6XjFbOip6w9R++reww==
 
-"@frontegg/rest-api@2.10.43":
-  version "2.10.43"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.43.tgz#d58062078246c2a496c17e1fe2c3533e555060dc"
-  integrity sha512-V+X+rxpkM8+cPEW4DId/SnuHTBHiIIcghYUF7RI+KkpvmUBVLbmo7q3XYnTKVijXP4FHIYChbAeRBnT5fXS80A==
+"@frontegg/rest-api@2.10.45":
+  version "2.10.45"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.45.tgz#f4d63ca6d10d238bfb4bdb908dce2aab0d13bb09"
+  integrity sha512-2Z5zGlZVL85Mg9Psi+d44Lrrl25fyTS89aAVD0/SRDBIpl8ebHIDD0w7d5BmqspB7y0l60ndwF6TnBhk2vusMw==
 
-"@frontegg/types@4.36.2":
-  version "4.36.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.36.2.tgz#8ce17d45186427ec02bf407e46279e0274be3f4d"
-  integrity sha512-LLIjrum9yXfrB0p7FGZOljTD8QQroL+zDHfroup38b5wrK4NTDO41V0RVj2Q3LWYVZMppTcjTHIf31FSWbxAcg==
+"@frontegg/types@4.37.0":
+  version "4.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.37.0.tgz#599c428cf7907485625693b38bb81689dc77f4a9"
+  integrity sha512-nvX1YcAwQWCx0EJBK5REGBzy/Tvc16IXS//vS556yeLdBKUSLuhSrJaSugV/rAvJjDJruBhhS4t2PdAICpppYA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 4.39.0:
- [FR-4552](https://frontegg.atlassian.net/browse/FR-4552) - users page sub tenants - [b64fc8d6](https://github.com/frontegg/admin-box/pulls?q=b64fc8d6)
- [FR-4365](https://frontegg.atlassian.net/browse/FR-4365) - change day(s) to day, days - [50fccb78](https://github.com/frontegg/admin-box/pulls?q=50fccb78)

### AdminPortal 4.38.0:
- [FR-4685](https://frontegg.atlassian.net/browse/FR-4685) - Subscriptions hidden stripe form - [9e05600b](https://github.com/frontegg/admin-box/pulls?q=9e05600b)

### AdminPortal 4.37.0:
- [FR-4618](https://frontegg.atlassian.net/browse/FR-4618) - added localization for MFA disable dialog validation - [cd67e494](https://github.com/frontegg/admin-box/pulls?q=cd67e494)
- [FR-4623](https://frontegg.atlassian.net/browse/FR-4623) - update rest api version - [b3b2485e](https://github.com/frontegg/admin-box/pulls?q=b3b2485e)