### PR TITLE
Update Frontegg AdminPortal to 4.42.2

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.42.1",
-    "@frontegg/redux-store": "4.42.1",
+    "@frontegg/admin-portal": "4.42.2",
+    "@frontegg/redux-store": "4.42.2",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.40.1",
-    "@frontegg/redux-store": "4.40.1",
+    "@frontegg/admin-portal": "4.41.0",
+    "@frontegg/redux-store": "4.41.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.41.0",
-    "@frontegg/redux-store": "4.41.0",
+    "@frontegg/admin-portal": "4.42.0",
+    "@frontegg/redux-store": "4.42.0",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.42.0",
-    "@frontegg/redux-store": "4.42.0",
+    "@frontegg/admin-portal": "4.42.1",
+    "@frontegg/redux-store": "4.42.1",
     "get-value": "^3.0.1",
     "set-value": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.41.0.tgz#1fc35dfc6c9e95f299ae878ab58067a234633d2f"
-  integrity sha512-cEhXULEFRjzJGWvvTjOravyuowR1NnouzQR/FvNvBnwMFwmEirh3laA5MT2HQm11H+WxJEnNJlExmSHdEcIFqw==
+"@frontegg/admin-portal@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.0.tgz#bedbbc4b136e99be741e86f5263d87ad464df19e"
+  integrity sha512-hRossNoUdP8YgsyHbvxq83/E2wiIQt4ngxN0lkPopy/j4e69XceAjYtMWosnkU13rRv28tFT+bVtpCcy+PsZhQ==
   dependencies:
-    "@frontegg/react-hooks" "4.41.0"
-    "@frontegg/types" "4.41.0"
+    "@frontegg/react-hooks" "4.42.0"
+    "@frontegg/types" "4.42.0"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -997,12 +997,12 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.23.tgz#d4fca57659c6b5fec913b801f0196a8c8e77512f"
   integrity sha512-aZNZCIHuZwPpkPkXTmBpJS3Ot8ID00vMuN8z1YGCvBKHzA6PhaitJV6ZxAUQweUG7suv872iNdNJFr85ObPOLg==
 
-"@frontegg/react-hooks@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.41.0.tgz#cbfcc41482c0aac135ac7fb80bedbef0057e78f4"
-  integrity sha512-0I6WnWZygkFiIltrl/mXw4jUAzdB3RZ/nPP9Aw3/O3fYvnKb+ODeHPOR7IyQrYUSAEJhIYVOWk4d8X5tY/5hjA==
+"@frontegg/react-hooks@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.0.tgz#100ec86e87e55dcbd172451698f5b1291d66ed19"
+  integrity sha512-CmsyhrSQ/DCfcelRld7bRNMMNQOapMw4jQ7bPcKtNj1WB4djn5yP/uVSuNYn5dg8dipusv+Kxc0i4ohYPTC+9w==
   dependencies:
-    "@frontegg/redux-store" "4.41.0"
+    "@frontegg/redux-store" "4.42.0"
     react-redux "^7.x"
 
 "@frontegg/redux-store@1.23.40":
@@ -1014,10 +1014,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.41.0.tgz#db74afc74f4ba76adf6aab294aea061bd5812d47"
-  integrity sha512-epn7neFWVeYeo1jhiRgJMUo/w9OhT8BVsegTGm+uG7dJ0hTCXX03TsQaz1/vEw8uYsNuA6Rp8+KdxqBZGTpLSQ==
+"@frontegg/redux-store@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.0.tgz#a15e0e18cee0abb0bd771ecc603f2ec78223c720"
+  integrity sha512-5KH1Wd7ctQeqL1wiNs8ZIrQO6YYaReVMk7RtfKBubD0EM4wO2BnJ4FYaNNvUlP4IGw809mnS/KpAqFyaDnSVJQ==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1035,10 +1035,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.41.0.tgz#3756526bc1f2c424c65db32db195cd7da80452f8"
-  integrity sha512-UZ9HWlUN7h6RsI/f59Oje6Wn5wENsV52IhL1Rw0/AkRb0E/7M6ZlQXAahlG4KgXJnDN6ERxUJF1VWFleaeufLg==
+"@frontegg/types@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.0.tgz#e8ac355e71856cc0765ba49c6f8d25f729a8163a"
+  integrity sha512-USoPIoGCsTS122Xu9mYB28cNGNOmFdAu3lvir8YAK827iwDP6JHNylCLp8jpEhI6A+SairqCCSlAZ+tm+vqSFA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.40.1.tgz#c78a6567212092d7e8679cf5822d0eb814a08ef1"
-  integrity sha512-IsftDxx2feeamGwGTEIHtBHpKXXzrdaNUZgjJAVgqbg5tXSi1jmVmjGvv/zywDhMD9wKb9+5bdEBBx12HvYWaQ==
+"@frontegg/admin-portal@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.41.0.tgz#1fc35dfc6c9e95f299ae878ab58067a234633d2f"
+  integrity sha512-cEhXULEFRjzJGWvvTjOravyuowR1NnouzQR/FvNvBnwMFwmEirh3laA5MT2HQm11H+WxJEnNJlExmSHdEcIFqw==
   dependencies:
-    "@frontegg/react-hooks" "4.40.1"
-    "@frontegg/types" "4.40.1"
+    "@frontegg/react-hooks" "4.41.0"
+    "@frontegg/types" "4.41.0"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -997,12 +997,12 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.23.tgz#d4fca57659c6b5fec913b801f0196a8c8e77512f"
   integrity sha512-aZNZCIHuZwPpkPkXTmBpJS3Ot8ID00vMuN8z1YGCvBKHzA6PhaitJV6ZxAUQweUG7suv872iNdNJFr85ObPOLg==
 
-"@frontegg/react-hooks@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.40.1.tgz#30071aba8ee2e45d0ddab177736d6b93e5142ec4"
-  integrity sha512-GoX844Z4D7b6R9OQ4fx9aqHhFICjiOBkKpj4m/xW2Vk6bHme4iQUMxZrkzjGqStnDsJyVmvQj6pcpYaYKB4yYA==
+"@frontegg/react-hooks@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.41.0.tgz#cbfcc41482c0aac135ac7fb80bedbef0057e78f4"
+  integrity sha512-0I6WnWZygkFiIltrl/mXw4jUAzdB3RZ/nPP9Aw3/O3fYvnKb+ODeHPOR7IyQrYUSAEJhIYVOWk4d8X5tY/5hjA==
   dependencies:
-    "@frontegg/redux-store" "4.40.1"
+    "@frontegg/redux-store" "4.41.0"
     react-redux "^7.x"
 
 "@frontegg/redux-store@1.23.40":
@@ -1014,12 +1014,12 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.40.1.tgz#4967dbf908265fe3fe6781585b5fd3f72b99f317"
-  integrity sha512-LORW4YScgOUPoZ7HJvJIUi6TZwv1D1n2QznFX4C2ZG666N23NI8ACEfiTW2s+oyd5q30vyk2MFt8Mb/LS/VNoA==
+"@frontegg/redux-store@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.41.0.tgz#db74afc74f4ba76adf6aab294aea061bd5812d47"
+  integrity sha512-epn7neFWVeYeo1jhiRgJMUo/w9OhT8BVsegTGm+uG7dJ0hTCXX03TsQaz1/vEw8uYsNuA6Rp8+KdxqBZGTpLSQ==
   dependencies:
-    "@frontegg/rest-api" "2.10.46"
+    "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
@@ -1030,15 +1030,15 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-1.23.40.tgz#ffbeb6097ac7b053073abcf84fc144cd5efadccc"
   integrity sha512-T08RWX2bv7fN6ax3xEguz6rrnbsnrVUhDcZhE2ij11rzo/VVw9QJ/A4l0RbyBuKDGJte6XjFbOip6w9R++reww==
 
-"@frontegg/rest-api@2.10.46":
-  version "2.10.46"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.46.tgz#47d59c385ff96927c5a6c0ae1baec8a01d479c83"
-  integrity sha512-YjQLnPZdH//Gb+b6FgLTDWSoBYFGZe9NqoTS3nuBNsQ+64LNtGH4OKUWU82/iByupPG3Uz7zOZAmxhYlKuEhaQ==
+"@frontegg/rest-api@2.10.47":
+  version "2.10.47"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
+  integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.40.1.tgz#11d494e07eb75816620283a903b4ab17990a3663"
-  integrity sha512-HqwCIAMLMrjjoiA4r/mh79YM3EP/cPI6reFrcdTIuoqs3eQsGJiht9Lq1XTa+ZdXJQd2ekgs3yDnlbKnlBx2/A==
+"@frontegg/types@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.41.0.tgz#3756526bc1f2c424c65db32db195cd7da80452f8"
+  integrity sha512-UZ9HWlUN7h6RsI/f59Oje6Wn5wENsV52IhL1Rw0/AkRb0E/7M6ZlQXAahlG4KgXJnDN6ERxUJF1VWFleaeufLg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.0.tgz#bedbbc4b136e99be741e86f5263d87ad464df19e"
-  integrity sha512-hRossNoUdP8YgsyHbvxq83/E2wiIQt4ngxN0lkPopy/j4e69XceAjYtMWosnkU13rRv28tFT+bVtpCcy+PsZhQ==
+"@frontegg/admin-portal@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.1.tgz#b5674e296182b9c0ede476b11ed52059b3b5328b"
+  integrity sha512-hdCnaIyBhxP+2comIh4+kyW6+aSdZgoVnpIk/A2DafZNhNX/echAU5mRbSxMVO4BC4n4n4yrV9xWmWok3XtgYQ==
   dependencies:
-    "@frontegg/react-hooks" "4.42.0"
-    "@frontegg/types" "4.42.0"
+    "@frontegg/react-hooks" "4.42.1"
+    "@frontegg/types" "4.42.1"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -997,12 +997,12 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.23.tgz#d4fca57659c6b5fec913b801f0196a8c8e77512f"
   integrity sha512-aZNZCIHuZwPpkPkXTmBpJS3Ot8ID00vMuN8z1YGCvBKHzA6PhaitJV6ZxAUQweUG7suv872iNdNJFr85ObPOLg==
 
-"@frontegg/react-hooks@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.0.tgz#100ec86e87e55dcbd172451698f5b1291d66ed19"
-  integrity sha512-CmsyhrSQ/DCfcelRld7bRNMMNQOapMw4jQ7bPcKtNj1WB4djn5yP/uVSuNYn5dg8dipusv+Kxc0i4ohYPTC+9w==
+"@frontegg/react-hooks@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.1.tgz#c90aad7a168b36e156306b0ee081362e15d88b77"
+  integrity sha512-/m8X1PA0S6l11eP0ndaG0u2JGR5qd6Hq7UEs7cksUDbzA1s/tXhXFPl2HWIIzYTzcvS/1Yvn6kOXXgdqESX4Sg==
   dependencies:
-    "@frontegg/redux-store" "4.42.0"
+    "@frontegg/redux-store" "4.42.1"
     react-redux "^7.x"
 
 "@frontegg/redux-store@1.23.40":
@@ -1014,10 +1014,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.0.tgz#a15e0e18cee0abb0bd771ecc603f2ec78223c720"
-  integrity sha512-5KH1Wd7ctQeqL1wiNs8ZIrQO6YYaReVMk7RtfKBubD0EM4wO2BnJ4FYaNNvUlP4IGw809mnS/KpAqFyaDnSVJQ==
+"@frontegg/redux-store@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.1.tgz#7fc313b68cdb70772e0e3973981f302c37eedac5"
+  integrity sha512-Di/NibgMI91LQws0Dsx5svT+7DGrR//GfPqUzyebvbtXL8jCz0Jawy3TLueg2lomNZkJUhKiEWdN5KCUnMMKWg==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1035,10 +1035,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.0.tgz#e8ac355e71856cc0765ba49c6f8d25f729a8163a"
-  integrity sha512-USoPIoGCsTS122Xu9mYB28cNGNOmFdAu3lvir8YAK827iwDP6JHNylCLp8jpEhI6A+SairqCCSlAZ+tm+vqSFA==
+"@frontegg/types@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.1.tgz#04413d9fa84fca6e6f60a2990de817daa3dcc2a3"
+  integrity sha512-LrDKzDep8XITOmFLPofWPevwx7eqPgxrZUxzzTQAKPnLToJwy+RIkXk0ZHfNizSeCXTd7+bStwD7HGgjw9kcAQ==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,13 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@4.42.1":
-  version "4.42.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.1.tgz#b5674e296182b9c0ede476b11ed52059b3b5328b"
-  integrity sha512-hdCnaIyBhxP+2comIh4+kyW6+aSdZgoVnpIk/A2DafZNhNX/echAU5mRbSxMVO4BC4n4n4yrV9xWmWok3XtgYQ==
+"@frontegg/admin-portal@4.42.2":
+  version "4.42.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.2.tgz#1a5e5a6ba94cbaafac0f651ffa9f9ae3373eb888"
+  integrity sha512-Nx88ids8mRbXXlWFZvkcAa2stjsdXvb0kvYO55BcVbvqd7kbxbP5QMb6XlwFUrFvfCMBYmrDoaz4vdsZdJMwNg==
   dependencies:
-    "@frontegg/react-hooks" "4.42.1"
-    "@frontegg/types" "4.42.1"
+    "@frontegg/react-hooks" "4.42.2"
+    "@frontegg/types" "4.42.2"
 
 "@frontegg/admin-portal@^0.5.2":
   version "0.5.2"
@@ -997,12 +997,12 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.23.tgz#d4fca57659c6b5fec913b801f0196a8c8e77512f"
   integrity sha512-aZNZCIHuZwPpkPkXTmBpJS3Ot8ID00vMuN8z1YGCvBKHzA6PhaitJV6ZxAUQweUG7suv872iNdNJFr85ObPOLg==
 
-"@frontegg/react-hooks@4.42.1":
-  version "4.42.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.1.tgz#c90aad7a168b36e156306b0ee081362e15d88b77"
-  integrity sha512-/m8X1PA0S6l11eP0ndaG0u2JGR5qd6Hq7UEs7cksUDbzA1s/tXhXFPl2HWIIzYTzcvS/1Yvn6kOXXgdqESX4Sg==
+"@frontegg/react-hooks@4.42.2":
+  version "4.42.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.2.tgz#1c15324413be408c0db11fe02fb2848f4d9bf970"
+  integrity sha512-UtEwGRHxOf4Id2OhYYyWxdjo1LeZpvUnaOBK+bbfwVxNriv6+uFYeNDJumagAsmQy4Q2uh1Xrcn3WICl5KwwCg==
   dependencies:
-    "@frontegg/redux-store" "4.42.1"
+    "@frontegg/redux-store" "4.42.2"
     react-redux "^7.x"
 
 "@frontegg/redux-store@1.23.40":
@@ -1014,10 +1014,10 @@
     "@reduxjs/toolkit" "1.x"
     redux-saga "1.x"
 
-"@frontegg/redux-store@4.42.1":
-  version "4.42.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.1.tgz#7fc313b68cdb70772e0e3973981f302c37eedac5"
-  integrity sha512-Di/NibgMI91LQws0Dsx5svT+7DGrR//GfPqUzyebvbtXL8jCz0Jawy3TLueg2lomNZkJUhKiEWdN5KCUnMMKWg==
+"@frontegg/redux-store@4.42.2":
+  version "4.42.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.2.tgz#9c8bb764cee689576877ff9dbab220647870761c"
+  integrity sha512-aS5nROL/aRf9Qdnw8zvjuoB1ajZ7/RoyukSZ+460RSQuKo2yxVbjImqN+4fZYX0HawHBBeJ6+xDSDnLyvBUILA==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1035,10 +1035,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.42.1":
-  version "4.42.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.1.tgz#04413d9fa84fca6e6f60a2990de817daa3dcc2a3"
-  integrity sha512-LrDKzDep8XITOmFLPofWPevwx7eqPgxrZUxzzTQAKPnLToJwy+RIkXk0ZHfNizSeCXTd7+bStwD7HGgjw9kcAQ==
+"@frontegg/types@4.42.2":
+  version "4.42.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.2.tgz#713e869f38697bffb5e2901082702fb332493583"
+  integrity sha512-7MvgPJdAt9wxhYlJAA69aILY9mNM/rtwrc7bydIPbWqddLxYadp6TXb938xUMhU7FtZCey2uRe1zsGtCNhWw+A==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 4.42.2:
- [FR-4943](https://frontegg.atlassian.net/browse/FR-4943) - add support for chrome/safari/firefox auto completion for login inputs - [eb37930a](https://github.com/frontegg/admin-box/pulls?q=eb37930a)
- [FR-4842](https://frontegg.atlassian.net/browse/FR-4842) - Fix validation error messages - [ef3a0da7](https://github.com/frontegg/admin-box/pulls?q=ef3a0da7)

### AdminPortal 4.42.1:
- [FR-4850](https://frontegg.atlassian.net/browse/FR-4850) - remove unused styles - [6ccb99bc](https://github.com/frontegg/admin-box/pulls?q=6ccb99bc)

### AdminPortal 4.42.0:
- [FR-4786](https://frontegg.atlassian.net/browse/FR-4786) - addded another hook on the react-hooks and type - [f3e7e9b7](https://github.com/frontegg/admin-box/pulls?q=f3e7e9b7)

### AdminPortal 4.41.0:
- [FR-4717](https://frontegg.atlassian.net/browse/FR-4717) - fix login error - [94408a24](https://github.com/frontegg/admin-box/pulls?q=94408a24)
- [FR-4786](https://frontegg.atlassian.net/browse/FR-4786) - supporting hosted login on login-box - [70523fdc](https://github.com/frontegg/admin-box/pulls?q=70523fdc)