### PR TITLE
Update Frontegg AdminPortal to 5.9.1

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.8.2",
-    "@frontegg/redux-store": "5.8.2",
+    "@frontegg/admin-portal": "5.9.0",
+    "@frontegg/redux-store": "5.9.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.9.0",
-    "@frontegg/redux-store": "5.9.0",
+    "@frontegg/admin-portal": "5.9.1",
+    "@frontegg/redux-store": "5.9.1",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,26 +970,27 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.8.2":
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.8.2.tgz#af226ea4f13a5a852df5c99c175ffa3a527ea507"
-  integrity sha512-i5+LeXZftdtmaGaOA84Bss6mw1b9mE5yZEYxdWHPnMPJmELNC2PalZPDb+VB+4pbjEVEbBmlAvLBmj33fAIV2Q==
+"@frontegg/admin-portal@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.9.0.tgz#7770b3e83f9003a661990ad8d2819bd9b8077c3a"
+  integrity sha512-AQvtw6JF6pTMgZGvpJvYb+ILtQv4iJhfZ/eIfuDq/Uyp197T7rBdW+k8balXmUm7AoQ4a50l8Wp8qQVY8zZsrQ==
   dependencies:
-    "@frontegg/react-hooks" "5.8.2"
-    "@frontegg/types" "5.8.2"
+    "@frontegg/react-hooks" "5.9.0"
+    "@frontegg/types" "5.9.0"
+    uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.8.2":
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.8.2.tgz#7bf5af9c5fa92817b818bd8010413ac91ec094db"
-  integrity sha512-XfCB9ZBWYw+JnifGOgD9aA3/QogjZlaYgEFY/FOD72dxmLyaINSDdfbYDjAKsM3H7S3KlWvONBHz4xFUk2F2ew==
+"@frontegg/react-hooks@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.9.0.tgz#ff0a9ea1bc0a9f3b0b02ed8ea2eb0ae72094c171"
+  integrity sha512-QBHSl2fYtgvzkjpkH2j0ttlJfat0/kAEIb8kO/orQqhHMcQv2KLwi2k9cwDMN6AiRxcB5MtLz1FTI86aaBrthQ==
   dependencies:
-    "@frontegg/redux-store" "5.8.2"
+    "@frontegg/redux-store" "5.9.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.8.2":
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.8.2.tgz#1da13dc6bbaa0b3260f7af7e9cb1cfb9a21ec176"
-  integrity sha512-F28knksLlTRJP+X4iqBKNLPCkGi2IlIk8an+x+tkZIlVgK4uzZOx7Dz6E+TdoBkJYr9Vk6tetRgZK+NBbKprDg==
+"@frontegg/redux-store@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.9.0.tgz#4c82bd9700c887f453df8bf5c5d8a4eccca45b2d"
+  integrity sha512-Cst9a+ZWztJPD7uAEIk+45yGdGRjHIA16FubqKc6FNLDx1nrUlFk5BzRzw8BT/ZqOPJRSm/LFG8df3DDbILsPw==
   dependencies:
     "@frontegg/rest-api" "2.10.49"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1002,10 +1003,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.49.tgz#8a2cd78ffa83ca105294395919277d611b341a24"
   integrity sha512-oVlq/cvHnIQnLzTLhOyzv3UIDvpSYSjTVX4YRLRCCn/5HqC2Bu6+IC5npHWYtKWdD5kFmFkCG6A9Njkq8Effmw==
 
-"@frontegg/types@5.8.2":
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.8.2.tgz#4b47100cfa83188f6dcc3ab3d3b0c3d73e50db49"
-  integrity sha512-hxBr4ErmI6M1emKi5ILkLhh22H17M9H3U9N5taDZYNtAcxFgjTACJUlglVnjGNmcbCKXFpHv3ywcO+Cmj/HFeA==
+"@frontegg/types@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.9.0.tgz#74c9f7c3b660de4a345710ba3fb0c2489bca9924"
+  integrity sha512-2ojLXqnk/uGkQ86ejMxRETqwZN4GnXRqCCmn8VjbbdyBRO0C5VdGaLcdbcGKB37AVP5xKCoLDevWcwDwYQczrw==
   dependencies:
     csstype "^3.0.9"
 
@@ -11926,7 +11927,7 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,27 +970,27 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.9.0.tgz#7770b3e83f9003a661990ad8d2819bd9b8077c3a"
-  integrity sha512-AQvtw6JF6pTMgZGvpJvYb+ILtQv4iJhfZ/eIfuDq/Uyp197T7rBdW+k8balXmUm7AoQ4a50l8Wp8qQVY8zZsrQ==
+"@frontegg/admin-portal@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.9.1.tgz#e39696994b131408a583a7bac5eb80d4394fe601"
+  integrity sha512-Q+qjUMdrGFKvU6P4uJ2Ngu1fENmGTNybbirFvg6O3g1NQqE5+S8MonzaRTF9XVjy/PyinzGQrIl70wRMuJvwdw==
   dependencies:
-    "@frontegg/react-hooks" "5.9.0"
-    "@frontegg/types" "5.9.0"
+    "@frontegg/react-hooks" "5.9.1"
+    "@frontegg/types" "5.9.1"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.9.0.tgz#ff0a9ea1bc0a9f3b0b02ed8ea2eb0ae72094c171"
-  integrity sha512-QBHSl2fYtgvzkjpkH2j0ttlJfat0/kAEIb8kO/orQqhHMcQv2KLwi2k9cwDMN6AiRxcB5MtLz1FTI86aaBrthQ==
+"@frontegg/react-hooks@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.9.1.tgz#16aea93fccc708984c6fea66eb43c84e75785de7"
+  integrity sha512-s3ylIf7hD6T6wgMpurCljYLxaK4vDg77cgZaaf8T0ceaG1jnU96Lx+Og/0XAumlS2NE7vWAwdxkFlwMQs5TNNg==
   dependencies:
-    "@frontegg/redux-store" "5.9.0"
+    "@frontegg/redux-store" "5.9.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.9.0.tgz#4c82bd9700c887f453df8bf5c5d8a4eccca45b2d"
-  integrity sha512-Cst9a+ZWztJPD7uAEIk+45yGdGRjHIA16FubqKc6FNLDx1nrUlFk5BzRzw8BT/ZqOPJRSm/LFG8df3DDbILsPw==
+"@frontegg/redux-store@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.9.1.tgz#2de307253cb346d949d7867796a12409167e9a62"
+  integrity sha512-gA3XmaHOpviCv8UN4nutGqQFyNkFsNJh+O04EC8y6drx0o4QOp65ebuj+WJXFyv7rIXrrFV4l1Rr1oBTbAGceA==
   dependencies:
     "@frontegg/rest-api" "2.10.49"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1003,10 +1003,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.49.tgz#8a2cd78ffa83ca105294395919277d611b341a24"
   integrity sha512-oVlq/cvHnIQnLzTLhOyzv3UIDvpSYSjTVX4YRLRCCn/5HqC2Bu6+IC5npHWYtKWdD5kFmFkCG6A9Njkq8Effmw==
 
-"@frontegg/types@5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.9.0.tgz#74c9f7c3b660de4a345710ba3fb0c2489bca9924"
-  integrity sha512-2ojLXqnk/uGkQ86ejMxRETqwZN4GnXRqCCmn8VjbbdyBRO0C5VdGaLcdbcGKB37AVP5xKCoLDevWcwDwYQczrw==
+"@frontegg/types@5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.9.1.tgz#8abf83df4b6b4712fc6f49551b5d0334bd65982a"
+  integrity sha512-m/rngQPSmGQQhcDBeW5arV2g1oJxt7UpOOiLEhyFKipmD/4ieyn5mLlMGrMh7vbr9rNocpeywieAn7VZ/AN3ug==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.9.1:
- [FR-5109](https://frontegg.atlassian.net/browse/FR-5109) - render social logins as icons only if more than 3 buttons - [52552828](https://github.com/frontegg/admin-box/pulls?q=52552828)

### AdminPortal 5.9.0:
- [FR-5159](https://frontegg.atlassian.net/browse/FR-5159) - fix sso model hight and steps title - [40c22cb0](https://github.com/frontegg/admin-box/pulls?q=40c22cb0)
- [FR-5282](https://frontegg.atlassian.net/browse/FR-5282) - nextjs uuid compile fix - [3db3b3ee](https://github.com/frontegg/admin-box/pulls?q=3db3b3ee)
- [FR-5106](https://frontegg.atlassian.net/browse/FR-5106) - add ability to handle refresh long refresh token - [ed1c629f](https://github.com/frontegg/admin-box/pulls?q=ed1c629f)
- [FR-4289](https://frontegg.atlassian.net/browse/FR-4289) - fix error state in login box - [e18936f4](https://github.com/frontegg/admin-box/pulls?q=e18936f4)