### PR TITLE
Update Frontegg AdminPortal to 5.18.2

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.18.1",
-    "@frontegg/redux-store": "5.18.1",
+    "@frontegg/admin-portal": "5.18.2",
+    "@frontegg/redux-store": "5.18.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.18.1.tgz#e84c2d549f1053602e54a17da800733c9a55de89"
-  integrity sha512-txQZcqChUoSVdxOdpSQkP9GuNE1FQh5VN+wmbnF+hANwoAiJc5Q38AtXr8KtjC6lhLrvEBC6dUVpsWTFhF6n2A==
+"@frontegg/admin-portal@5.18.2":
+  version "5.18.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.18.2.tgz#0df5b66e248604fc79b5e46ed8cec7e4a9e6abe5"
+  integrity sha512-5RnEc7g2tCWHpiEW0Aa4F3mbSbP3n4dXjKKt1G9JzWEsxqRMSbnZqbtpPk/pRDo6AJkTH1EwnfgZR8iWcEVy6A==
   dependencies:
-    "@frontegg/types" "5.18.1"
+    "@frontegg/types" "5.18.2"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.18.1.tgz#78c6eb00b82ac1b957a0818da7a70481370eff62"
-  integrity sha512-DUKXDZru4Q/pVBrBzEopp6ML4SPLOjiskUZZQ1EWoWR+FSDjU5wZDtdhgsyiKXZvkOAJHh+ThOL+Qtsi3In9DA==
+"@frontegg/redux-store@5.18.2":
+  version "5.18.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.18.2.tgz#83831ee0434725444797238e1a99296ba243e4e0"
+  integrity sha512-bCjRjttaL2M5WVU4J13HjqZF+IIKZlP+Bjkf3QvGBGRHxDRZ2Aj0l5uvwn2wdvg6iPaCe8TxaUCxDnBg86Iqmw==
   dependencies:
     "@frontegg/rest-api" "2.10.51"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.51.tgz#e938fd5344f78b20bcd308fd9181b16fd2fea62c"
   integrity sha512-yvecsIDJlCTustcuy4Be0KOYP+9rKODEDKm5BR7PqSI7Q35koEBu4XjMdL2BH4fTN5JvmNAQ2TwIY00dN1QIiQ==
 
-"@frontegg/types@5.18.1":
-  version "5.18.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.18.1.tgz#40d6d86ae5d704004e36bbe1ddfcae76e55f8367"
-  integrity sha512-2MoxBlvFqxY/lG2Ua/1AENP2NdJffvT1qsTYKb71vHwPEb6P1dK2NzOvIIXBEDYAiLyl/LbsrbOhH4Or49untQ==
+"@frontegg/types@5.18.2":
+  version "5.18.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.18.2.tgz#503f5e355fa44d5327fc4ec47fd7c98d1e67dbd6"
+  integrity sha512-lnkhYpjflSc8YwfXPKcXlcN22tUymz9cq2nwoT58Pvhf6J9J20UDyzGoUgBgXS5TrjC1+MYzqkn+XPPozr57FA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.18.2:
- [FR-6001](https://frontegg.atlassian.net/browse/FR-6001) - clean @frontegg/types from React nodes - [b330190c](https://github.com/frontegg/admin-box/pulls?q=b330190c)
- [FR-5607](https://frontegg.atlassian.net/browse/FR-5607) - Add support for hooks in custom components - [206b1654](https://github.com/frontegg/admin-box/pulls?q=206b1654)