### PR TITLE
Update Frontegg AdminPortal to 5.19.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.18.3",
-    "@frontegg/redux-store": "5.18.3",
+    "@frontegg/admin-portal": "5.19.0",
+    "@frontegg/redux-store": "5.19.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.18.3":
-  version "5.18.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.18.3.tgz#8a53f82e449e72ca5f8a7c693620469beee81cc1"
-  integrity sha512-u0LL4GkE3PAHDDOmjX+m39ikhvuck47Y8CW5LjcqNYbWBBfQpUxTgaOe0KStkDDdOzirOJqkiUJqhkyUmIktpg==
+"@frontegg/admin-portal@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.19.0.tgz#a97b352b0d3f63e6090c6ee12d3a4a584d714f7d"
+  integrity sha512-2nWvajGDS4c/BJakM0nARB3Dlf2JAQBv4B3wPxq77VC/WaRwPRCMkCtj2mnT2PoZI/CjQziGSRQlOyUlTpK2GQ==
   dependencies:
-    "@frontegg/types" "5.18.3"
+    "@frontegg/types" "5.19.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.18.3":
-  version "5.18.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.18.3.tgz#fa64261fc7a03b9af70aa54fb4e33496715206a0"
-  integrity sha512-MFwVDsbdH4UNPA3+fSL1dLkWTqM6W6LjmosNShbK0Mw8ZYwjvbCpBQHRh/Wz8y95/a3BzEUVHA15wVLlu0tSwA==
+"@frontegg/redux-store@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.19.0.tgz#a15d0cb0a43c46f3751833d9e7bef63f02ed2dd2"
+  integrity sha512-aVcJ+Svpso1YD7fW5p0IW5y530I3R+A1YQRTAelM9VfinSrDbFhE8qTZbA/gw0SVpCAHk4++CBIwlY+z2vUW8A==
   dependencies:
     "@frontegg/rest-api" "2.10.51"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.51.tgz#e938fd5344f78b20bcd308fd9181b16fd2fea62c"
   integrity sha512-yvecsIDJlCTustcuy4Be0KOYP+9rKODEDKm5BR7PqSI7Q35koEBu4XjMdL2BH4fTN5JvmNAQ2TwIY00dN1QIiQ==
 
-"@frontegg/types@5.18.3":
-  version "5.18.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.18.3.tgz#6c553d147db3136a8e6331616a2af775185af323"
-  integrity sha512-S0eljshKOxUzH0Go+lZuDXUS4zGvCa/x+aIsm9mqG6FE2IXbweRx+Gq/ynxuBOtrrjzlo1M2EmQ6rIK/9dt2DQ==
+"@frontegg/types@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.19.0.tgz#9149da1465a94b0f63e1b0c2976c8ce080add457"
+  integrity sha512-dlztlIpsjyhdXQ7LoYDh8zClTyuDBUqnS1yDv4nxvSCta3inPszox3Xj0wxORYOAzDjC3j5eyM58InONBLSOMA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.19.0:
- [FR-6007](https://frontegg.atlassian.net/browse/FR-6007) - Success activate screen should be shown also when MFA is forced - [d05be180](https://github.com/frontegg/admin-box/pulls?q=d05be180)