### PR TITLE
Update Frontegg AdminPortal to 5.49.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.48.0",
-    "@frontegg/redux-store": "5.48.0",
+    "@frontegg/admin-portal": "5.49.0",
+    "@frontegg/redux-store": "5.49.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.46.0",
-    "@frontegg/redux-store": "5.46.0",
+    "@frontegg/admin-portal": "5.48.0",
+    "@frontegg/redux-store": "5.48.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.48.0":
-  version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.48.0.tgz#1973c3b56aa7f37cf4699454c5fe6c4155f7198d"
-  integrity sha512-4fNdi8IaQwljcmYsRrpJd332nDpCWkRD0nmCvy5qzzs6VXp2VZXS7JL2MF83c2Tq1SGjQzn41sVNbMQrhMMM+Q==
+"@frontegg/admin-portal@5.49.0":
+  version "5.49.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.49.0.tgz#44b878fd1ddc45d73a3634fbf6bcb5be6fedeac9"
+  integrity sha512-AShmwgYYAgOhggc7H5gdH102AvW0xL7Vn6NplZe5gteap9RDkTb9l4ZFe4Lt7qTfAMVQ5a9S0FjbOw/zG4pxyw==
   dependencies:
-    "@frontegg/types" "5.48.0"
+    "@frontegg/types" "5.49.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.48.0":
-  version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.48.0.tgz#b4751adbfe1f4381e98f45442fa3a2d67ced141f"
-  integrity sha512-2t2G6UDDQBr+17LOjM66OVZo9Q+1IvGTrJbyPUEVQ+QG+VAf28Seltr2IwE+B8lTwHhQTDtEIClycCnAtOCsBA==
+"@frontegg/redux-store@5.49.0":
+  version "5.49.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.49.0.tgz#00dd4e3cd34f1a94d2ddb672c40d335ffbc70038"
+  integrity sha512-W9v274L7x0vNL6399xcCKUciSsok/w55XhFqfQdbT5GrlLKZh4axc64BY4XywWv8ceFmYPrQF5GK+cJ/XBGMRA==
   dependencies:
     "@frontegg/rest-api" "2.10.66"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.66.tgz#be21930ce6d24883bb74917c2cd407a30ecad0a6"
   integrity sha512-I9/E3dpN2WNjj3s+dlbZCCF/o3lIDxy1BZPOilfwmdulEF7UtwhBxWLwQgS9cGKA/feWGESnsEX0JFM/SyT6gw==
 
-"@frontegg/types@5.48.0":
-  version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.48.0.tgz#4d68e8afb384889580132b2912943e8bdf1cab45"
-  integrity sha512-JBVFCZBIMOWA7iFCpmbUE4FahrjLePxfrfl2jYjJVyPbr2pNnn+UhJ4RpT+PAPWuCDfFbTDgGem1+VuAzOT8Kw==
+"@frontegg/types@5.49.0":
+  version "5.49.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.49.0.tgz#fc6d7348f2a44694ecde013cadb9edc497cdc2ef"
+  integrity sha512-Psw0nUE3xl8wBNkmRARCqVzuGIk7SwnT1xafa8aQ7TWfCBuyw/mSYyDYMjPF21a6smnYYfPM8vYAfu5sqTOYwg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,34 +963,34 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.46.0":
-  version "5.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.46.0.tgz#bef19276ff58668e2785db085bc7080ec7ffd06c"
-  integrity sha512-MSGgbta1eZK9zBES3nSTSf+s2/9SEeN7uZNk2kG18wbyta8h7RFXCQjMo5sTTcnh2fOVmh1D2GWf1+SK1rDMMA==
+"@frontegg/admin-portal@5.48.0":
+  version "5.48.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.48.0.tgz#1973c3b56aa7f37cf4699454c5fe6c4155f7198d"
+  integrity sha512-4fNdi8IaQwljcmYsRrpJd332nDpCWkRD0nmCvy5qzzs6VXp2VZXS7JL2MF83c2Tq1SGjQzn41sVNbMQrhMMM+Q==
   dependencies:
-    "@frontegg/types" "5.46.0"
+    "@frontegg/types" "5.48.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.46.0":
-  version "5.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.46.0.tgz#f147613989a7fafe25545b7c7c6236238d49b7bb"
-  integrity sha512-LG6ZcFiEzGqynE5G5oHqXw967uoaX8jmZid4NuFV7p1gzAHAQjlnNg3z1Wy0NYVvYkJGIocWUw54PUsHbKXPlg==
+"@frontegg/redux-store@5.48.0":
+  version "5.48.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.48.0.tgz#b4751adbfe1f4381e98f45442fa3a2d67ced141f"
+  integrity sha512-2t2G6UDDQBr+17LOjM66OVZo9Q+1IvGTrJbyPUEVQ+QG+VAf28Seltr2IwE+B8lTwHhQTDtEIClycCnAtOCsBA==
   dependencies:
-    "@frontegg/rest-api" "2.10.65"
+    "@frontegg/rest-api" "2.10.66"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.65":
-  version "2.10.65"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.65.tgz#fc0d14602c0bf2ac46b62ea1c4a90bd8f609d1dc"
-  integrity sha512-wKns7eujRAcJV7gFOQSbckiRKl0qalPfNw8zGk8T0MkfTe2+4tOO0wl/nQP7oB70LdLeQDhgzQwWdS8bihgM3w==
+"@frontegg/rest-api@2.10.66":
+  version "2.10.66"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.66.tgz#be21930ce6d24883bb74917c2cd407a30ecad0a6"
+  integrity sha512-I9/E3dpN2WNjj3s+dlbZCCF/o3lIDxy1BZPOilfwmdulEF7UtwhBxWLwQgS9cGKA/feWGESnsEX0JFM/SyT6gw==
 
-"@frontegg/types@5.46.0":
-  version "5.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.46.0.tgz#d76a571595d96a613334ccdea8aa6adc82f62421"
-  integrity sha512-O2Nw1P5fO7Eui7M0qY4YS2kVZ5hMUbEoVULKVRVhGGNq6wAOY4Mv3s0jqQpLtP4oDsy40vGts272IhEt1ZLeYA==
+"@frontegg/types@5.48.0":
+  version "5.48.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.48.0.tgz#4d68e8afb384889580132b2912943e8bdf1cab45"
+  integrity sha512-JBVFCZBIMOWA7iFCpmbUE4FahrjLePxfrfl2jYjJVyPbr2pNnn+UhJ4RpT+PAPWuCDfFbTDgGem1+VuAzOT8Kw==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.49.0:
- [FR-7381](https://frontegg.atlassian.net/browse/FR-7381) - Builder / admin box modules / webhooks event are not selectable - [b2791c21](https://github.com/frontegg/admin-box/pulls?q=b2791c21)
- [FR-7176](https://frontegg.atlassian.net/browse/FR-7176) - Subscriptions Checkout Dialog Component - [6e2bda48](https://github.com/frontegg/admin-box/pulls?q=6e2bda48)
- [FR-7172](https://frontegg.atlassian.net/browse/FR-7172) - Privacy tests - [b15e7ba0](https://github.com/frontegg/admin-box/pulls?q=b15e7ba0)

### AdminPortal 5.48.0:
- [FR-7372](https://frontegg.atlassian.net/browse/FR-7372) - update phone validation - [33e7f452](https://github.com/frontegg/admin-box/pulls?q=33e7f452)