### PR TITLE
Update Frontegg AdminPortal to 5.53.1

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.51.1",
-    "@frontegg/redux-store": "5.51.1",
+    "@frontegg/admin-portal": "5.51.2",
+    "@frontegg/redux-store": "5.51.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.51.2",
-    "@frontegg/redux-store": "5.51.2",
+    "@frontegg/admin-portal": "5.52.0",
+    "@frontegg/redux-store": "5.52.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.51.0",
-    "@frontegg/redux-store": "5.51.0",
+    "@frontegg/admin-portal": "5.51.1",
+    "@frontegg/redux-store": "5.51.1",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.52.0",
-    "@frontegg/redux-store": "5.52.0",
+    "@frontegg/admin-portal": "5.53.1",
+    "@frontegg/redux-store": "5.53.1",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.50.0",
-    "@frontegg/redux-store": "5.50.0",
+    "@frontegg/admin-portal": "5.51.0",
+    "@frontegg/redux-store": "5.51.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.52.0.tgz#4384adfd4235d476155235602e4736d119cdf6b4"
-  integrity sha512-nBHuzdXyxfeXCwPmZmdQqwtkcC4+lc120yZEhzVfyVqYFK5qF/4WyqHSzq3JLlLSGK/Njdw563I6usX7Mt2VaQ==
+"@frontegg/admin-portal@5.53.1":
+  version "5.53.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.1.tgz#01a7b366bde531a5e47ac0ee1c3930b9a9a85e93"
+  integrity sha512-h/YKHcNNxE4nevNN0yEFFSLsEJvXdkUeOJXPy83BYIhnJfyMhVD90HxKjuK3/PQf4SP7RDq3FouV37Nnhku7Pg==
   dependencies:
-    "@frontegg/types" "5.52.0"
+    "@frontegg/types" "5.53.1"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.52.0.tgz#986769c293a3f61e03aabc87056c069dd566c09e"
-  integrity sha512-O+wiMy9QaGSnijkgJeebuYQ/3K8Wbreg8NsQiz6G5Z22vMNtsBBWmPThB55QkZl4pDaPaG5RnorrnivX1C3HwA==
+"@frontegg/redux-store@5.53.1":
+  version "5.53.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.1.tgz#b72e941272e797f89e401a1c1170169789bf4c4d"
+  integrity sha512-6CS55YjkvCO+asdrXTeXPybBY6TmYSb5gK5SibC/Iojj/eyOuL48LvXayeUDfXtOmtaYRu3dmqRkgryPPhGVow==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.52.0":
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.52.0.tgz#e0a0b5b7d607561b16e4c34251ea66b44deea70b"
-  integrity sha512-1cocScfuz4fOOPU5R5NMYzcWobf/8sWT2RB6uiVO9AmRp0kDalQaHn23zumhaIsO4QenR5/L5ly44PROZbKtdA==
+"@frontegg/types@5.53.1":
+  version "5.53.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.1.tgz#1f01e34e0cd115f0636b3cfc1aeadfd32d4b2d16"
+  integrity sha512-FMryBaa3rx73ybDIsFZ6geZNHhLpEv7z/gxsUHkE386K7E9eogd8IAYjlByQP9GbDpmxr7RKdcqMl6IX2/lqZQ==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.51.0.tgz#b0ae733dea07bf1e6de22443c96cc7907af953d4"
-  integrity sha512-EG0zobEJic+34O1WleMyIUgGIgXF/7YefwMbMW+fRVjN2m5zszxstxyBzOX5qSOjkAU+3BNj6XLxYIBnmFgrvQ==
+"@frontegg/admin-portal@5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.51.1.tgz#0244bac0863315e593daa5a1ebb733e4a025f08c"
+  integrity sha512-yw8lCe0li8ceVCbnvh308z1xz4CZQrbUUnyoTH8LKX18i8Km4nxJz7qeoDHYV4DYyMbHBeJYCFqP0w3R4cc0NQ==
   dependencies:
-    "@frontegg/types" "5.51.0"
+    "@frontegg/types" "5.51.1"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.51.0.tgz#c7ac9a4b1b37c4d85d3247b68a0d8d31e52a367b"
-  integrity sha512-kJ9cziG2ZT6id1mP9dWJxBblWq/Uq7oUrQjUGZ2u/LB2Zuulg8gYQCeXaehcHqVX7mBwlo+NyDlU6huBiv5/lQ==
+"@frontegg/redux-store@5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.51.1.tgz#831cfcd729970c0ae8d3770b6404a2c97f7d8fc2"
+  integrity sha512-pzLJ6jtxBTIIesjk8CD7vGpoUv0A/4bBPyLO5ibcP5izkn30+/A5DiOtQEnt/QE+cCHXW86xMZN4wZpBGySg9w==
   dependencies:
     "@frontegg/rest-api" "2.10.67"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.67.tgz#5b6f39fa7dc018f8106add9db96cce341a98af47"
   integrity sha512-RkNsgD32UUQH+1Q4JIcdoXmlZ0lNtCnECpGjK5Ipq3Lne6fEl/dpd/SRHQ9W0g8WkYXe6GL97S0MfqkHZS76zA==
 
-"@frontegg/types@5.51.0":
-  version "5.51.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.51.0.tgz#625bdb5b5ca4428069b9e77a6c75fbad6aab490d"
-  integrity sha512-5Pct1qzALPO51Q5fbXk5cEUANyQIudnLbb7U+OJzcsngvquvFoFb7aWyuuli9QohKlwtrUCAas7CtnXymdJ0mw==
+"@frontegg/types@5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.51.1.tgz#e384f5866838b240d446961a2831b22bc567f06c"
+  integrity sha512-zceuaP1nTwEeyQTYkCq1o1pAUC+AHsQPBcv4jYBNW7wnBAT90Zqhy2bPiF6cFO6LM0W92Hduq2ZWgtOQTwOWHg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,34 +963,34 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.51.2":
-  version "5.51.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.51.2.tgz#821d87a3089096c3ce98037f4aa5dd428dd10dcd"
-  integrity sha512-QSVjI5pFZQi3QVHIdC8wwYzKsyGAlaFIQNc1qPIsrmpkXBieRw2DjSpCWroF8c+wB18x1rnvsWkugV4wSa43Rg==
+"@frontegg/admin-portal@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.52.0.tgz#4384adfd4235d476155235602e4736d119cdf6b4"
+  integrity sha512-nBHuzdXyxfeXCwPmZmdQqwtkcC4+lc120yZEhzVfyVqYFK5qF/4WyqHSzq3JLlLSGK/Njdw563I6usX7Mt2VaQ==
   dependencies:
-    "@frontegg/types" "5.51.2"
+    "@frontegg/types" "5.52.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.51.2":
-  version "5.51.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.51.2.tgz#ea342c9f5edf1383fb8f8ae305cb824e30056af1"
-  integrity sha512-FB7yj7GBMXJzAAO/3w3eIQ6kHAOI2LNag9PBmwV06T1pKSrWFTCKe0UzmHTHyn5Pw/X4BvrpgkdtbGeiPV2xEQ==
+"@frontegg/redux-store@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.52.0.tgz#986769c293a3f61e03aabc87056c069dd566c09e"
+  integrity sha512-O+wiMy9QaGSnijkgJeebuYQ/3K8Wbreg8NsQiz6G5Z22vMNtsBBWmPThB55QkZl4pDaPaG5RnorrnivX1C3HwA==
   dependencies:
-    "@frontegg/rest-api" "2.10.67"
+    "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.67":
-  version "2.10.67"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.67.tgz#5b6f39fa7dc018f8106add9db96cce341a98af47"
-  integrity sha512-RkNsgD32UUQH+1Q4JIcdoXmlZ0lNtCnECpGjK5Ipq3Lne6fEl/dpd/SRHQ9W0g8WkYXe6GL97S0MfqkHZS76zA==
+"@frontegg/rest-api@2.10.72":
+  version "2.10.72"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
+  integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.51.2":
-  version "5.51.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.51.2.tgz#40f8fac8b54b90bcb91e4669d663548747310e3f"
-  integrity sha512-trbmLBTdRdA6vqit57iHhOEfWdah/px4cxYDsqk5YOjn4PRkZEHAGjRoMXuVxn8OIFCERbjtybReKKLRKJXBUw==
+"@frontegg/types@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.52.0.tgz#e0a0b5b7d607561b16e4c34251ea66b44deea70b"
+  integrity sha512-1cocScfuz4fOOPU5R5NMYzcWobf/8sWT2RB6uiVO9AmRp0kDalQaHn23zumhaIsO4QenR5/L5ly44PROZbKtdA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.51.1":
-  version "5.51.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.51.1.tgz#0244bac0863315e593daa5a1ebb733e4a025f08c"
-  integrity sha512-yw8lCe0li8ceVCbnvh308z1xz4CZQrbUUnyoTH8LKX18i8Km4nxJz7qeoDHYV4DYyMbHBeJYCFqP0w3R4cc0NQ==
+"@frontegg/admin-portal@5.51.2":
+  version "5.51.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.51.2.tgz#821d87a3089096c3ce98037f4aa5dd428dd10dcd"
+  integrity sha512-QSVjI5pFZQi3QVHIdC8wwYzKsyGAlaFIQNc1qPIsrmpkXBieRw2DjSpCWroF8c+wB18x1rnvsWkugV4wSa43Rg==
   dependencies:
-    "@frontegg/types" "5.51.1"
+    "@frontegg/types" "5.51.2"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.51.1":
-  version "5.51.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.51.1.tgz#831cfcd729970c0ae8d3770b6404a2c97f7d8fc2"
-  integrity sha512-pzLJ6jtxBTIIesjk8CD7vGpoUv0A/4bBPyLO5ibcP5izkn30+/A5DiOtQEnt/QE+cCHXW86xMZN4wZpBGySg9w==
+"@frontegg/redux-store@5.51.2":
+  version "5.51.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.51.2.tgz#ea342c9f5edf1383fb8f8ae305cb824e30056af1"
+  integrity sha512-FB7yj7GBMXJzAAO/3w3eIQ6kHAOI2LNag9PBmwV06T1pKSrWFTCKe0UzmHTHyn5Pw/X4BvrpgkdtbGeiPV2xEQ==
   dependencies:
     "@frontegg/rest-api" "2.10.67"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.67.tgz#5b6f39fa7dc018f8106add9db96cce341a98af47"
   integrity sha512-RkNsgD32UUQH+1Q4JIcdoXmlZ0lNtCnECpGjK5Ipq3Lne6fEl/dpd/SRHQ9W0g8WkYXe6GL97S0MfqkHZS76zA==
 
-"@frontegg/types@5.51.1":
-  version "5.51.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.51.1.tgz#e384f5866838b240d446961a2831b22bc567f06c"
-  integrity sha512-zceuaP1nTwEeyQTYkCq1o1pAUC+AHsQPBcv4jYBNW7wnBAT90Zqhy2bPiF6cFO6LM0W92Hduq2ZWgtOQTwOWHg==
+"@frontegg/types@5.51.2":
+  version "5.51.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.51.2.tgz#40f8fac8b54b90bcb91e4669d663548747310e3f"
+  integrity sha512-trbmLBTdRdA6vqit57iHhOEfWdah/px4cxYDsqk5YOjn4PRkZEHAGjRoMXuVxn8OIFCERbjtybReKKLRKJXBUw==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.50.0.tgz#de421e28cb9f697f43e57d76b6edf0e2664f9c0d"
-  integrity sha512-XVje3DUNFG8SgA3qYc5wzl8e/v18M1CxG+86hFntlmSmqXqZHWUwfEPdx+8I9kBu2IHEP3cVblLnMNOWpgA+XQ==
+"@frontegg/admin-portal@5.51.0":
+  version "5.51.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.51.0.tgz#b0ae733dea07bf1e6de22443c96cc7907af953d4"
+  integrity sha512-EG0zobEJic+34O1WleMyIUgGIgXF/7YefwMbMW+fRVjN2m5zszxstxyBzOX5qSOjkAU+3BNj6XLxYIBnmFgrvQ==
   dependencies:
-    "@frontegg/types" "5.50.0"
+    "@frontegg/types" "5.51.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.50.0.tgz#6b07d72cfafe89cfe6cf7e965699384f658e8ebe"
-  integrity sha512-d6SM8AchEzzSTXhrpj71MNsl44lWsagP8RlOb34zL86CzkJpBILXKnncNc1h72o1zq8YghP6wzjlxKKiuzdMqQ==
+"@frontegg/redux-store@5.51.0":
+  version "5.51.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.51.0.tgz#c7ac9a4b1b37c4d85d3247b68a0d8d31e52a367b"
+  integrity sha512-kJ9cziG2ZT6id1mP9dWJxBblWq/Uq7oUrQjUGZ2u/LB2Zuulg8gYQCeXaehcHqVX7mBwlo+NyDlU6huBiv5/lQ==
   dependencies:
     "@frontegg/rest-api" "2.10.67"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.67.tgz#5b6f39fa7dc018f8106add9db96cce341a98af47"
   integrity sha512-RkNsgD32UUQH+1Q4JIcdoXmlZ0lNtCnECpGjK5Ipq3Lne6fEl/dpd/SRHQ9W0g8WkYXe6GL97S0MfqkHZS76zA==
 
-"@frontegg/types@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.50.0.tgz#04eda7cf23e798c27217fd5e8eae29ae8ed95911"
-  integrity sha512-agZ6LLAjQmT9QQXxoMtC1YRV430UqsDJewMsy3AaqBq1t9WCWm67JoYBItFIX4JvZFfDxQCmtsogvIdHRIu+Iw==
+"@frontegg/types@5.51.0":
+  version "5.51.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.51.0.tgz#625bdb5b5ca4428069b9e77a6c75fbad6aab490d"
+  integrity sha512-5Pct1qzALPO51Q5fbXk5cEUANyQIudnLbb7U+OJzcsngvquvFoFb7aWyuuli9QohKlwtrUCAas7CtnXymdJ0mw==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.53.1:
- [FR-7726](https://frontegg.atlassian.net/browse/FR-7726) - Dummy commit for releasing a version - [969e112d](https://github.com/frontegg/admin-box/pulls?q=969e112d)

### AdminPortal 5.52.0:
- [FR-5604](https://frontegg.atlassian.net/browse/FR-5604) - Update rest api version for NextJS routes - [4f877fa9](https://github.com/frontegg/admin-box/pulls?q=4f877fa9)
- [FR-7408](https://frontegg.atlassian.net/browse/FR-7408) - Subscription Trial Ended Text update - [17c1c6fc](https://github.com/frontegg/admin-box/pulls?q=17c1c6fc)

### AdminPortal 5.51.2:
- [FR-7623](https://frontegg.atlassian.net/browse/FR-7623) - dummy commit for releasing a version - [f7d68b6e](https://github.com/frontegg/admin-box/pulls?q=f7d68b6e)

### AdminPortal 5.51.1:
- [FR-7623](https://frontegg.atlassian.net/browse/FR-7623) - Builder / admin portal preview - workspace subtitle is being shown even if not tabs appears. - [ec64c0c1](https://github.com/frontegg/admin-box/pulls?q=ec64c0c1)

### AdminPortal 5.51.0:
- [FR-6969](https://frontegg.atlassian.net/browse/FR-6969) - terms and conditions - [79fc940a](https://github.com/frontegg/admin-box/pulls?q=79fc940a)
- [FR-7623](https://frontegg.atlassian.net/browse/FR-7623) - Builder / admin portal preview - workspace subtitle is being showed even if no tabs appear - [390700a2](https://github.com/frontegg/admin-box/pulls?q=390700a2)
- [FR-7171](https://frontegg.atlassian.net/browse/FR-7171) - security tests - [304b9ee7](https://github.com/frontegg/admin-box/pulls?q=304b9ee7)