### PR TITLE
Update Frontegg AdminPortal to 5.54.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.53.4",
-    "@frontegg/redux-store": "5.53.4",
+    "@frontegg/admin-portal": "5.54.0",
+    "@frontegg/redux-store": "5.54.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.53.2",
-    "@frontegg/redux-store": "5.53.2",
+    "@frontegg/admin-portal": "5.53.3",
+    "@frontegg/redux-store": "5.53.3",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.53.3",
-    "@frontegg/redux-store": "5.53.3",
+    "@frontegg/admin-portal": "5.53.4",
+    "@frontegg/redux-store": "5.53.4",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.53.1",
-    "@frontegg/redux-store": "5.53.1",
+    "@frontegg/admin-portal": "5.53.2",
+    "@frontegg/redux-store": "5.53.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.53.4":
-  version "5.53.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.4.tgz#8168197c1aa3ed6ce7ceeb4205bb65339e9e0132"
-  integrity sha512-GgEhps4SG6OJxhK+lqLTIzA/+Z0uMSl6PRnG5UVidUzkBR7AH2xNCbiHG+n6Y5AHM8Tw4pM9nuMCq15Quxswhw==
+"@frontegg/admin-portal@5.54.0":
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.54.0.tgz#0082987f65e5ebea3ef5c65fe9309f15297d3a22"
+  integrity sha512-EKpU77PGw3o1vQR9SqaWow7Hz+jOs4p42IaQDKXHU33f7/Qe4dB6Y/ya1SmylpPvWLzfu24QACxQj84fj9N1kg==
   dependencies:
-    "@frontegg/types" "5.53.4"
+    "@frontegg/types" "5.54.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.53.4":
-  version "5.53.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.4.tgz#15a06aa44183d4dbebb576f78cb6cf01a8b6c9bd"
-  integrity sha512-wnuq4UpVZxVdTx7t3xmuScnxvn9LA6/qtaOqSqvJHrPY5AC5/9R0kA0Urb27m79JQ+OrQB5z5CITFLX96bMuFg==
+"@frontegg/redux-store@5.54.0":
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.54.0.tgz#7064a1f6e6814dad7f4d6d6b7a5817c29614e9a5"
+  integrity sha512-1Pq5ESBY72CeN9YayKdhoi20xuHiR7jHJLYGmiJTaEcGgHhrwEv6r6q85PPeMfX5EJfcHEQ1s1wVQ07T7YLcug==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.53.4":
-  version "5.53.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.4.tgz#9a220fe0b4393c99b05f227adb0b85e09517e1bd"
-  integrity sha512-W+vOaR7LcDJSyvpeC5Bk2dsA2DnD8ufc71YYRD+K0Uw/N5y4h3c2ZjWBYhppW5uab96vcawcFbHcOnoOPMfo1Q==
+"@frontegg/types@5.54.0":
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.54.0.tgz#a3ba9b19ed02f6d1bdc162cbbf05c95dee42873d"
+  integrity sha512-KQ1kxpPOjnJ+Wpa6xVwd+Gz1RjDvIXzeI7e631ovdMluB13H0bQM6bJs/evvePU9eFnUWHhHUAygVPG8+yK3Pw==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.53.3":
-  version "5.53.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.3.tgz#4b551ca8c05ba8c5df7c91027d3f37908b435b84"
-  integrity sha512-3Hc5ra3L/UHwk9SuFygij8wi8CmAXmuFRWir07b/EWDys5mFKOgtWg0ihCtANe269wiPXX+v4lr1kYD6vCV35Q==
+"@frontegg/admin-portal@5.53.4":
+  version "5.53.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.4.tgz#8168197c1aa3ed6ce7ceeb4205bb65339e9e0132"
+  integrity sha512-GgEhps4SG6OJxhK+lqLTIzA/+Z0uMSl6PRnG5UVidUzkBR7AH2xNCbiHG+n6Y5AHM8Tw4pM9nuMCq15Quxswhw==
   dependencies:
-    "@frontegg/types" "5.53.3"
+    "@frontegg/types" "5.53.4"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.53.3":
-  version "5.53.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.3.tgz#42578cf54e91c20a55660845eaef76cde4d4f6fe"
-  integrity sha512-lR+KcLX47Qjk5j1WQqT2sssbCjAYIO7PpEKwiUwub3IeSVam6E4/z85U5kkMWRAEKKbOV88rl1LRJ9rOENogJg==
+"@frontegg/redux-store@5.53.4":
+  version "5.53.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.4.tgz#15a06aa44183d4dbebb576f78cb6cf01a8b6c9bd"
+  integrity sha512-wnuq4UpVZxVdTx7t3xmuScnxvn9LA6/qtaOqSqvJHrPY5AC5/9R0kA0Urb27m79JQ+OrQB5z5CITFLX96bMuFg==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.53.3":
-  version "5.53.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.3.tgz#ac0447347cb98da88f8e046035d2a70922a1826f"
-  integrity sha512-ndCpGuWZ8fKq56kldN62cW4wIKqNvADPJPRJwji6BNwB/5HH0Sng76vTTI2CefWyK20wJmMSiOo2b97N/e5gyg==
+"@frontegg/types@5.53.4":
+  version "5.53.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.4.tgz#9a220fe0b4393c99b05f227adb0b85e09517e1bd"
+  integrity sha512-W+vOaR7LcDJSyvpeC5Bk2dsA2DnD8ufc71YYRD+K0Uw/N5y4h3c2ZjWBYhppW5uab96vcawcFbHcOnoOPMfo1Q==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.53.2":
-  version "5.53.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.2.tgz#0817f24f414c22f794713cf3cd6df73f7faa1f69"
-  integrity sha512-Z/Uq+QGJk2VxCajb4GgPmZZ4yVjQHy2LD4NoxSmMCGRhXWOC3zP1VUnzAsKcWZHp4zp+VQTJiKq/fJeI9Atyjg==
+"@frontegg/admin-portal@5.53.3":
+  version "5.53.3"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.3.tgz#4b551ca8c05ba8c5df7c91027d3f37908b435b84"
+  integrity sha512-3Hc5ra3L/UHwk9SuFygij8wi8CmAXmuFRWir07b/EWDys5mFKOgtWg0ihCtANe269wiPXX+v4lr1kYD6vCV35Q==
   dependencies:
-    "@frontegg/types" "5.53.2"
+    "@frontegg/types" "5.53.3"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.53.2":
-  version "5.53.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.2.tgz#fb7842ee5309f163269d5e6ff021dfe6e77e7637"
-  integrity sha512-bWuB/rnhISSRReHIEAgLXHEJU+0JMmrCJZbMZ79VHDddWSJRs7rVYt+qn12Q+6/01TMe2VZlRKIZypYTPavHPg==
+"@frontegg/redux-store@5.53.3":
+  version "5.53.3"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.3.tgz#42578cf54e91c20a55660845eaef76cde4d4f6fe"
+  integrity sha512-lR+KcLX47Qjk5j1WQqT2sssbCjAYIO7PpEKwiUwub3IeSVam6E4/z85U5kkMWRAEKKbOV88rl1LRJ9rOENogJg==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.53.2":
-  version "5.53.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.2.tgz#c30e2b8b9660527a01519479e873eba34c8e6b44"
-  integrity sha512-rLs8MO0yicKJ1x9dfwJxP3RJkFEsFVDyLzfNNssaBXbZLQ27AOrTgLXQBM3X5hlCM37XP6e5UTDtVow+0eWtTQ==
+"@frontegg/types@5.53.3":
+  version "5.53.3"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.3.tgz#ac0447347cb98da88f8e046035d2a70922a1826f"
+  integrity sha512-ndCpGuWZ8fKq56kldN62cW4wIKqNvADPJPRJwji6BNwB/5HH0Sng76vTTI2CefWyK20wJmMSiOo2b97N/e5gyg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.53.1":
-  version "5.53.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.1.tgz#01a7b366bde531a5e47ac0ee1c3930b9a9a85e93"
-  integrity sha512-h/YKHcNNxE4nevNN0yEFFSLsEJvXdkUeOJXPy83BYIhnJfyMhVD90HxKjuK3/PQf4SP7RDq3FouV37Nnhku7Pg==
+"@frontegg/admin-portal@5.53.2":
+  version "5.53.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.2.tgz#0817f24f414c22f794713cf3cd6df73f7faa1f69"
+  integrity sha512-Z/Uq+QGJk2VxCajb4GgPmZZ4yVjQHy2LD4NoxSmMCGRhXWOC3zP1VUnzAsKcWZHp4zp+VQTJiKq/fJeI9Atyjg==
   dependencies:
-    "@frontegg/types" "5.53.1"
+    "@frontegg/types" "5.53.2"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.53.1":
-  version "5.53.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.1.tgz#b72e941272e797f89e401a1c1170169789bf4c4d"
-  integrity sha512-6CS55YjkvCO+asdrXTeXPybBY6TmYSb5gK5SibC/Iojj/eyOuL48LvXayeUDfXtOmtaYRu3dmqRkgryPPhGVow==
+"@frontegg/redux-store@5.53.2":
+  version "5.53.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.2.tgz#fb7842ee5309f163269d5e6ff021dfe6e77e7637"
+  integrity sha512-bWuB/rnhISSRReHIEAgLXHEJU+0JMmrCJZbMZ79VHDddWSJRs7rVYt+qn12Q+6/01TMe2VZlRKIZypYTPavHPg==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.53.1":
-  version "5.53.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.1.tgz#1f01e34e0cd115f0636b3cfc1aeadfd32d4b2d16"
-  integrity sha512-FMryBaa3rx73ybDIsFZ6geZNHhLpEv7z/gxsUHkE386K7E9eogd8IAYjlByQP9GbDpmxr7RKdcqMl6IX2/lqZQ==
+"@frontegg/types@5.53.2":
+  version "5.53.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.2.tgz#c30e2b8b9660527a01519479e873eba34c8e6b44"
+  integrity sha512-rLs8MO0yicKJ1x9dfwJxP3RJkFEsFVDyLzfNNssaBXbZLQ27AOrTgLXQBM3X5hlCM37XP6e5UTDtVow+0eWtTQ==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.54.0:
- [FR-5604](https://frontegg.atlassian.net/browse/FR-5604) - render children if hosted login - [690b9b03](https://github.com/frontegg/admin-box/pulls?q=690b9b03)

### AdminPortal 5.53.4:
- [FR-7793](https://frontegg.atlassian.net/browse/FR-7793) - fix Audit logs crash on severity column - [4aaaca2c](https://github.com/frontegg/admin-box/pulls?q=4aaaca2c)

### AdminPortal 5.53.3:
- [FR-7775](https://frontegg.atlassian.net/browse/FR-7775) - fix tests for disclaimer checkbox - [e7f41291](https://github.com/frontegg/admin-box/pulls?q=e7f41291)
- [FR-7782](https://frontegg.atlassian.net/browse/FR-7782) - Update CODEOWNERS - [c01b14fa](https://github.com/frontegg/admin-box/pulls?q=c01b14fa)
- [FR-7775](https://frontegg.atlassian.net/browse/FR-7775) - change default text of disclaimer checkbox label - [e287e94a](https://github.com/frontegg/admin-box/pulls?q=e287e94a)

### AdminPortal 5.53.2:
- [FR-7706](https://frontegg.atlassian.net/browse/FR-7706) - checkout dialog app remove plan selection - [8cf0a2c2](https://github.com/frontegg/admin-box/pulls?q=8cf0a2c2)