### PR TITLE
Update Frontegg AdminPortal to 5.56.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.55.0",
-    "@frontegg/redux-store": "5.55.0",
+    "@frontegg/admin-portal": "5.56.0",
+    "@frontegg/redux-store": "5.56.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.54.1",
-    "@frontegg/redux-store": "5.54.1",
+    "@frontegg/admin-portal": "5.54.2",
+    "@frontegg/redux-store": "5.54.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.54.2",
-    "@frontegg/redux-store": "5.54.2",
+    "@frontegg/admin-portal": "5.55.0",
+    "@frontegg/redux-store": "5.55.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.54.1":
-  version "5.54.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.54.1.tgz#b351095376b76bd586c4d9fc49b7d3abac614bbe"
-  integrity sha512-P7z/+d1kdL36MXCatZAbUrJB43gBmCLsWle2pV95ystODlPr4yyBIw2AmeetX1IFPy0zmZmVQ2Odp4Py3DVhbw==
+"@frontegg/admin-portal@5.54.2":
+  version "5.54.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.54.2.tgz#636002f6e3131e6e9de1d5c95749e4ccf6666be4"
+  integrity sha512-j3HAemwLU1ZreUCGVhIWrb3zX7Kj3N77rR/OM7RJamBdriJXxg8xp1kozQefJifT0zoZdoBzSRp8PiLGgW7KMQ==
   dependencies:
-    "@frontegg/types" "5.54.1"
+    "@frontegg/types" "5.54.2"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.54.1":
-  version "5.54.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.54.1.tgz#89a0a143ae3475255dff3e15c70ad7074eeb002a"
-  integrity sha512-1omM9YZ0IdnG4DizUFjcVVHo91nxH4oTbAtPn24vMS+2+nVg5kFl23dnjLO5hzeSGnS9CqluwK3jcYgV+9gRLA==
+"@frontegg/redux-store@5.54.2":
+  version "5.54.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.54.2.tgz#256b37b6518e90f48cd8868057da7ce211ecda75"
+  integrity sha512-PkwemqKHuaqyCWYRXho3BMUzmuyH7W/Aqmg9yA3OFqGzIYkTmuCIMRH4DokgeDHviLc9nNT9TU9Va0jD49gMLA==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.54.1":
-  version "5.54.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.54.1.tgz#c18888fed06c888b415d4b9cb368139a10d8a010"
-  integrity sha512-n9PioED/jiKCPb6T6MUTiKtGc7jD4i7RnY0bG8wfJEEMVsZfy6esctzw7ScV0bc9b16RMziE2rMOi4yhNrPkYQ==
+"@frontegg/types@5.54.2":
+  version "5.54.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.54.2.tgz#7373438a6baea19d5a1713cdf96dfc7a70b2f408"
+  integrity sha512-4cQxYsyKx5UincgGUfZOb8GjOVrmJiMFEPD+xzocWbvs1s3s0Xn6xvO5ej5KEY3CwR//VCrO1lfMb6k10XQ2xg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,34 +963,34 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.55.0":
-  version "5.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.55.0.tgz#10e21842c38485d8e00741d91eb4bc17181fef32"
-  integrity sha512-6oPh58h0BJ6980VYWtjh3Mh5T5VXuscr7csGZUdWA0BFr5Ar+vrTnCvc+MtLkNjnBrlIGyjR9d8dgG8lMWMxsw==
+"@frontegg/admin-portal@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.56.0.tgz#e4ad954e1f1d34ee18c8b4ffdbf87f7770ae6f9d"
+  integrity sha512-vynLvuwtbpYUPJ9l2DP2pfUm4zJ+U2wVhulQMyAJoUSt0h3drVT2o/JqBAGL4i7QbkTnG6Vq31JwN7Yyjc0foA==
   dependencies:
-    "@frontegg/types" "5.55.0"
+    "@frontegg/types" "5.56.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.55.0":
-  version "5.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.55.0.tgz#e560b27f0b5db05b4b672061f7096a1fafe8119e"
-  integrity sha512-UmpTOZG5QH7BSMqh5LPnMy82Lplg+JbqR4BzEzXjgRsKrMWoir14ARY1fBhU6/q0p7SMschnkePl+tGr7kfOoQ==
+"@frontegg/redux-store@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.56.0.tgz#6c22f4ff6441ff610dc1ef63e202d7654f29c3cf"
+  integrity sha512-FNBZJ9GaqX7piBHWRc+URU/4cFaHOzOn5fOe10x3SinCCe02CG36ON9pjRqJAc4PVPUptVuOMq8JjfS1kzX/9Q==
   dependencies:
-    "@frontegg/rest-api" "2.10.72"
+    "@frontegg/rest-api" "2.10.73"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.72":
-  version "2.10.72"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
-  integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
+"@frontegg/rest-api@2.10.73":
+  version "2.10.73"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.73.tgz#dc370164bedb896319d24e26640376c4e7c09703"
+  integrity sha512-dtLkg99lddw3lBGlM8w9oHi1F2dOJrbHwACPikrqxUejQP97uNWxBlNElwFBYHeRReGSnHaw34KJrAEq/OoWJQ==
 
-"@frontegg/types@5.55.0":
-  version "5.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.55.0.tgz#bede5a818b2af12f84529f29d79974e6d531aa2a"
-  integrity sha512-C5M0KfxblssOMRki5aB3LOtuRzHtBEefaeI0276iKpmefUczvjyNLUDvsUyOmpC897QZMs1NeUleY7VcOlcRYg==
+"@frontegg/types@5.56.0":
+  version "5.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.56.0.tgz#b3787426a8d62a030b291ff55ad3d2224bf3e092"
+  integrity sha512-qse9DUxXOHBLO/h/LWw0OnSqJYcaypTRjSVc8KB8WRQPaF2twmF/2FIJvRGKaC/2aSBr12z4+5zu/dvSBNauYg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.54.2":
-  version "5.54.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.54.2.tgz#636002f6e3131e6e9de1d5c95749e4ccf6666be4"
-  integrity sha512-j3HAemwLU1ZreUCGVhIWrb3zX7Kj3N77rR/OM7RJamBdriJXxg8xp1kozQefJifT0zoZdoBzSRp8PiLGgW7KMQ==
+"@frontegg/admin-portal@5.55.0":
+  version "5.55.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.55.0.tgz#10e21842c38485d8e00741d91eb4bc17181fef32"
+  integrity sha512-6oPh58h0BJ6980VYWtjh3Mh5T5VXuscr7csGZUdWA0BFr5Ar+vrTnCvc+MtLkNjnBrlIGyjR9d8dgG8lMWMxsw==
   dependencies:
-    "@frontegg/types" "5.54.2"
+    "@frontegg/types" "5.55.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.54.2":
-  version "5.54.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.54.2.tgz#256b37b6518e90f48cd8868057da7ce211ecda75"
-  integrity sha512-PkwemqKHuaqyCWYRXho3BMUzmuyH7W/Aqmg9yA3OFqGzIYkTmuCIMRH4DokgeDHviLc9nNT9TU9Va0jD49gMLA==
+"@frontegg/redux-store@5.55.0":
+  version "5.55.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.55.0.tgz#e560b27f0b5db05b4b672061f7096a1fafe8119e"
+  integrity sha512-UmpTOZG5QH7BSMqh5LPnMy82Lplg+JbqR4BzEzXjgRsKrMWoir14ARY1fBhU6/q0p7SMschnkePl+tGr7kfOoQ==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.54.2":
-  version "5.54.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.54.2.tgz#7373438a6baea19d5a1713cdf96dfc7a70b2f408"
-  integrity sha512-4cQxYsyKx5UincgGUfZOb8GjOVrmJiMFEPD+xzocWbvs1s3s0Xn6xvO5ej5KEY3CwR//VCrO1lfMb6k10XQ2xg==
+"@frontegg/types@5.55.0":
+  version "5.55.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.55.0.tgz#bede5a818b2af12f84529f29d79974e6d531aa2a"
+  integrity sha512-C5M0KfxblssOMRki5aB3LOtuRzHtBEefaeI0276iKpmefUczvjyNLUDvsUyOmpC897QZMs1NeUleY7VcOlcRYg==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.56.0:
- [FR-7903](https://frontegg.atlassian.net/browse/FR-7903) - update rest-api version - [3f95786b](https://github.com/frontegg/admin-box/pulls?q=3f95786b)

### AdminPortal 5.55.0:
- 

### AdminPortal 5.54.2:
- [FR-5604](https://frontegg.atlassian.net/browse/FR-5604) - Prevent disable loading if hosted login and NextJS until SSR finished - [c7a34e93](https://github.com/frontegg/admin-box/pulls?q=c7a34e93)