### PR TITLE
Update Frontegg AdminPortal to 5.57.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.56.0",
-    "@frontegg/redux-store": "5.56.0",
+    "@frontegg/admin-portal": "5.57.0",
+    "@frontegg/redux-store": "5.57.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,34 +963,34 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.56.0.tgz#e4ad954e1f1d34ee18c8b4ffdbf87f7770ae6f9d"
-  integrity sha512-vynLvuwtbpYUPJ9l2DP2pfUm4zJ+U2wVhulQMyAJoUSt0h3drVT2o/JqBAGL4i7QbkTnG6Vq31JwN7Yyjc0foA==
+"@frontegg/admin-portal@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.0.tgz#6f209d50f08ea0f14fbdbdb8fa0838970243f18b"
+  integrity sha512-a8iAjh67Y1Cqu/vayOVsN7IT+5HA5GASmw91g7IZq7WxwqqPPlp+al/Pp/JV3FRx2z70YPp1sFJGGdiEtd/NFg==
   dependencies:
-    "@frontegg/types" "5.56.0"
+    "@frontegg/types" "5.57.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.56.0.tgz#6c22f4ff6441ff610dc1ef63e202d7654f29c3cf"
-  integrity sha512-FNBZJ9GaqX7piBHWRc+URU/4cFaHOzOn5fOe10x3SinCCe02CG36ON9pjRqJAc4PVPUptVuOMq8JjfS1kzX/9Q==
+"@frontegg/redux-store@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.0.tgz#5106d99997db69d08fdb7d0df89275cca358e9b2"
+  integrity sha512-1DxBXn2paG8NANkAA5Un5Z+oCHsaNufHQtZqZs8T0DPLjh2E3eiwXk1z4Pz2T0DuS/aDfqueuqyrrtXw+Wh9CQ==
   dependencies:
-    "@frontegg/rest-api" "2.10.73"
+    "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.73":
-  version "2.10.73"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.73.tgz#dc370164bedb896319d24e26640376c4e7c09703"
-  integrity sha512-dtLkg99lddw3lBGlM8w9oHi1F2dOJrbHwACPikrqxUejQP97uNWxBlNElwFBYHeRReGSnHaw34KJrAEq/OoWJQ==
+"@frontegg/rest-api@2.10.74":
+  version "2.10.74"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
+  integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.56.0":
-  version "5.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.56.0.tgz#b3787426a8d62a030b291ff55ad3d2224bf3e092"
-  integrity sha512-qse9DUxXOHBLO/h/LWw0OnSqJYcaypTRjSVc8KB8WRQPaF2twmF/2FIJvRGKaC/2aSBr12z4+5zu/dvSBNauYg==
+"@frontegg/types@5.57.0":
+  version "5.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.0.tgz#10b0543356ae4a48c9f1b085c0ead40b6833d00b"
+  integrity sha512-EDniornzPs1UeAOdLXDGwu9CZj8rP7NH5tG15U7wC/oL6xHcBJOL5yGqfCSIB9J41eWUk/VaxbqIm0jR0iv9EQ==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.57.0:
- [FR-7910](https://frontegg.atlassian.net/browse/FR-7910) - align mfa options with vendor policy - [0d817085](https://github.com/frontegg/admin-box/pulls?q=0d817085)
- [FR-7898](https://frontegg.atlassian.net/browse/FR-7898) - Showing a proper error if the vendor policy is not found - [2301032b](https://github.com/frontegg/admin-box/pulls?q=2301032b)