### PR TITLE
Update Frontegg AdminPortal to 5.58.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.57.1",
-    "@frontegg/redux-store": "5.57.1",
+    "@frontegg/admin-portal": "5.57.2",
+    "@frontegg/redux-store": "5.57.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.57.2",
-    "@frontegg/redux-store": "5.57.2",
+    "@frontegg/admin-portal": "5.57.4",
+    "@frontegg/redux-store": "5.57.4",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.57.4",
-    "@frontegg/redux-store": "5.57.4",
+    "@frontegg/admin-portal": "5.58.0",
+    "@frontegg/redux-store": "5.58.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.57.0",
-    "@frontegg/redux-store": "5.57.0",
+    "@frontegg/admin-portal": "5.57.1",
+    "@frontegg/redux-store": "5.57.1",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.57.4":
-  version "5.57.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.4.tgz#8675c963f26527169303e71072147dfdee0c4790"
-  integrity sha512-nSlfyQWO5GaBsoqcbxZFN7HKPnHFMgy4Nlgy+bLtscIE4eiadScJx2IzxKgF9Jq2fW1StP4jhPn7SjPtiDHeIQ==
+"@frontegg/admin-portal@5.58.0":
+  version "5.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.58.0.tgz#6590aae0448272872b928fed603ad82b5633e838"
+  integrity sha512-xdHue3Z5/CIUSci799lCvfMiufMJeU6jwS8cA1qn0+eAIem7mXFk249poBKynibZq4CAvGxQHcFjFoZ5VQHWxQ==
   dependencies:
-    "@frontegg/types" "5.57.4"
+    "@frontegg/types" "5.58.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.57.4":
-  version "5.57.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.4.tgz#3dac2a00128f5fe9522dd8a8f36d7c8414bbfaac"
-  integrity sha512-tAqFVCp4zE5+htgWdxrhyxLTIkI+ZfPCR0z0V8cGvH9BSC1Fm6etQtAtPbbzG8g4bjyeff4sgO22mKTkrzxECA==
+"@frontegg/redux-store@5.58.0":
+  version "5.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.58.0.tgz#5896d4eabacfa1416c605d6f235a1687683f92c5"
+  integrity sha512-wt4izUNPUTglwpZ2+enqIIxxn/JfLg/Q7U1X7nByn5ul4OWVmValbALFmXr6SI+s3MZ4uKv0rkqhBiCnQIx0jQ==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.57.4":
-  version "5.57.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.4.tgz#5d2501d2a15a2b20936c06962b121aa5604429e6"
-  integrity sha512-pb5n4hRKCDrJsRCxtel5z5rtLjHnKmsgRKk+CAyfQto37f2TiFRDvkVuJxdcEGMxiDNRHTohU+AHM84aFv95rQ==
+"@frontegg/types@5.58.0":
+  version "5.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.58.0.tgz#62d8c0cbf7f041418c708ad0a5f9971a09455a78"
+  integrity sha512-i8YxdXlvt1no1ACboTgpmPjAH1hWbVdzphVcBFZDHiahDX9N5Yuzz5ndZaqHnU4W2CAKHNLmIjeg/Jm29Vd4fA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.0.tgz#6f209d50f08ea0f14fbdbdb8fa0838970243f18b"
-  integrity sha512-a8iAjh67Y1Cqu/vayOVsN7IT+5HA5GASmw91g7IZq7WxwqqPPlp+al/Pp/JV3FRx2z70YPp1sFJGGdiEtd/NFg==
+"@frontegg/admin-portal@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.1.tgz#ad954ed87d9c5946fc260eea27bfe9b2fe585c49"
+  integrity sha512-0+C5lBeobtLz7KP3PeNFX4Y0Ly460PzjODgnxceaeZ04BvNI2IuPdOfRQu14Drck073ePAkIS0JvT2+N28tjZg==
   dependencies:
-    "@frontegg/types" "5.57.0"
+    "@frontegg/types" "5.57.1"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.0.tgz#5106d99997db69d08fdb7d0df89275cca358e9b2"
-  integrity sha512-1DxBXn2paG8NANkAA5Un5Z+oCHsaNufHQtZqZs8T0DPLjh2E3eiwXk1z4Pz2T0DuS/aDfqueuqyrrtXw+Wh9CQ==
+"@frontegg/redux-store@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.1.tgz#98faca46e9318bb31304bba7ef1545ba99fe0bc2"
+  integrity sha512-0nLd61WbU1154acW0JRTTl8rTlR9NMnhAT2zEf60GZq/QohKoIpvXwBnnXIs782gtwbLE8s2en2+6dUPqJh4UQ==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.0.tgz#10b0543356ae4a48c9f1b085c0ead40b6833d00b"
-  integrity sha512-EDniornzPs1UeAOdLXDGwu9CZj8rP7NH5tG15U7wC/oL6xHcBJOL5yGqfCSIB9J41eWUk/VaxbqIm0jR0iv9EQ==
+"@frontegg/types@5.57.1":
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.1.tgz#fd374138934552a857f31e9fd407260d3e2adcc7"
+  integrity sha512-+zP+ay2AeNAEe5RrmxkK7anRJpgKfsbybHtAx+80oDjzxGcFMNZrK+7XdJYYVftsqb3tJ0nuvL7LMqvXIEqkFg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.57.1":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.1.tgz#ad954ed87d9c5946fc260eea27bfe9b2fe585c49"
-  integrity sha512-0+C5lBeobtLz7KP3PeNFX4Y0Ly460PzjODgnxceaeZ04BvNI2IuPdOfRQu14Drck073ePAkIS0JvT2+N28tjZg==
+"@frontegg/admin-portal@5.57.2":
+  version "5.57.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.2.tgz#6822f8776f12792a62073a0d1b8b1a90e8a1d96c"
+  integrity sha512-hq0TuSpbo/BnLWIXXjJYRhWi+gYpxCSSDPa0S+PfHi2LE8LGSny4UInieTb9S6xoDvU2C+7USdEVNkD5++/JcQ==
   dependencies:
-    "@frontegg/types" "5.57.1"
+    "@frontegg/types" "5.57.2"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.57.1":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.1.tgz#98faca46e9318bb31304bba7ef1545ba99fe0bc2"
-  integrity sha512-0nLd61WbU1154acW0JRTTl8rTlR9NMnhAT2zEf60GZq/QohKoIpvXwBnnXIs782gtwbLE8s2en2+6dUPqJh4UQ==
+"@frontegg/redux-store@5.57.2":
+  version "5.57.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.2.tgz#d2c6baa79cc067d5194c9626391e039406d5dda1"
+  integrity sha512-QfR6N7G9VFx8ybf9D05UI9x3TBwOld2RnOkvCUfAvI2P9eK7Sj1oAByf7TdjtjRyWh0KV20GkRxv6Tr6+sOA4g==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.57.1":
-  version "5.57.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.1.tgz#fd374138934552a857f31e9fd407260d3e2adcc7"
-  integrity sha512-+zP+ay2AeNAEe5RrmxkK7anRJpgKfsbybHtAx+80oDjzxGcFMNZrK+7XdJYYVftsqb3tJ0nuvL7LMqvXIEqkFg==
+"@frontegg/types@5.57.2":
+  version "5.57.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.2.tgz#b9da19ffca5afb6520ba9be4854ff409306d6017"
+  integrity sha512-Xpt4jjaTUehOw2KI5CR38PzVri414mjYTZCeyRMraNTc0wtpY+y5/P7eNmGcXeNS9eW4nCvOZ1zSDPCd2CUWxA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.57.2":
-  version "5.57.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.2.tgz#6822f8776f12792a62073a0d1b8b1a90e8a1d96c"
-  integrity sha512-hq0TuSpbo/BnLWIXXjJYRhWi+gYpxCSSDPa0S+PfHi2LE8LGSny4UInieTb9S6xoDvU2C+7USdEVNkD5++/JcQ==
+"@frontegg/admin-portal@5.57.4":
+  version "5.57.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.57.4.tgz#8675c963f26527169303e71072147dfdee0c4790"
+  integrity sha512-nSlfyQWO5GaBsoqcbxZFN7HKPnHFMgy4Nlgy+bLtscIE4eiadScJx2IzxKgF9Jq2fW1StP4jhPn7SjPtiDHeIQ==
   dependencies:
-    "@frontegg/types" "5.57.2"
+    "@frontegg/types" "5.57.4"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.57.2":
-  version "5.57.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.2.tgz#d2c6baa79cc067d5194c9626391e039406d5dda1"
-  integrity sha512-QfR6N7G9VFx8ybf9D05UI9x3TBwOld2RnOkvCUfAvI2P9eK7Sj1oAByf7TdjtjRyWh0KV20GkRxv6Tr6+sOA4g==
+"@frontegg/redux-store@5.57.4":
+  version "5.57.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.57.4.tgz#3dac2a00128f5fe9522dd8a8f36d7c8414bbfaac"
+  integrity sha512-tAqFVCp4zE5+htgWdxrhyxLTIkI+ZfPCR0z0V8cGvH9BSC1Fm6etQtAtPbbzG8g4bjyeff4sgO22mKTkrzxECA==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.57.2":
-  version "5.57.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.2.tgz#b9da19ffca5afb6520ba9be4854ff409306d6017"
-  integrity sha512-Xpt4jjaTUehOw2KI5CR38PzVri414mjYTZCeyRMraNTc0wtpY+y5/P7eNmGcXeNS9eW4nCvOZ1zSDPCd2CUWxA==
+"@frontegg/types@5.57.4":
+  version "5.57.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.57.4.tgz#5d2501d2a15a2b20936c06962b121aa5604429e6"
+  integrity sha512-pb5n4hRKCDrJsRCxtel5z5rtLjHnKmsgRKk+CAyfQto37f2TiFRDvkVuJxdcEGMxiDNRHTohU+AHM84aFv95rQ==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.58.0:
- [FR-5604](https://frontegg.atlassian.net/browse/FR-5604) - show children only hosted login and nextjs - [52d1f0ee](https://github.com/frontegg/admin-box/pulls?q=52d1f0ee)

### AdminPortal 5.57.4:
- [FR-7659](https://frontegg.atlassian.net/browse/FR-7659) - dummy commit - [2f382e91](https://github.com/frontegg/admin-box/pulls?q=2f382e91)

### AdminPortal 5.57.2:
- [FR-7411](https://frontegg.atlassian.net/browse/FR-7411) - add new themes for new layout - [8491882f](https://github.com/frontegg/admin-box/pulls?q=8491882f)
- [FR-7659](https://frontegg.atlassian.net/browse/FR-7659) - Fixes for social login buttons - [b3592c5f](https://github.com/frontegg/admin-box/pulls?q=b3592c5f)

### AdminPortal 5.57.1:
- [FR-7659](https://frontegg.atlassian.net/browse/FR-7659) - Social login layout customization - [e4a8bb1d](https://github.com/frontegg/admin-box/pulls?q=e4a8bb1d)