### PR TITLE
Update Frontegg AdminPortal to 5.59.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.58.1",
-    "@frontegg/redux-store": "5.58.1",
+    "@frontegg/admin-portal": "5.59.0",
+    "@frontegg/redux-store": "5.59.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.58.0",
-    "@frontegg/redux-store": "5.58.0",
+    "@frontegg/admin-portal": "5.58.1",
+    "@frontegg/redux-store": "5.58.1",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.58.1":
-  version "5.58.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.58.1.tgz#f4b30a8c754959f4bf6264d1f13db04f54c8d919"
-  integrity sha512-o7CjWI+22EQss7bRpjvNkllQZn3c6cmTUzTKIEqRXUust2S62nEfH6oUxOeV5cn67RAi2q67tP6wiRDvtzS4EA==
+"@frontegg/admin-portal@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.59.0.tgz#926eabae86f58437ddef291a4033c0b3687efc0e"
+  integrity sha512-oqzFQZoOW5el8nTk4QKRf2UYlD3UcEDzdIvJJyxUZORQRkLSZDfV4NWmJs7wRqAG+zJBXDUjDl4OzWrB3qg4dw==
   dependencies:
-    "@frontegg/types" "5.58.1"
+    "@frontegg/types" "5.59.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.58.1":
-  version "5.58.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.58.1.tgz#7cc32a9b5b3e547b90b9098fb3b1a4500cb2754f"
-  integrity sha512-stvMKlNkgf0lw7HwBU73nZY6N9ug2nAiJCqvvnU2jCn7oQpPZUMW0cb2B2u9ftsjoiGfIiXKPvM+Cp5wqYBBiA==
+"@frontegg/redux-store@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.59.0.tgz#b84e3cf4bcdf8c8aa7d3379370a175d73d02c324"
+  integrity sha512-P+6peBouvIDkBx4FVF08uY/knws4QBdomwokbZjdI8FUnVqggJ6qE1tftIjtuTIgd7cltKbJoFCEOaSYoGPqnw==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.58.1":
-  version "5.58.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.58.1.tgz#ffbdd94be894c2a74e7d98574dbf97112d4fba6c"
-  integrity sha512-MUEM46EvPs8yNTNCEWH0xUD+s8Vq5oXxbtq7M69mtyCJPfRZrXAmN6mWJdJCpF8MJNNjbRyEKRDVEWItqwoPoA==
+"@frontegg/types@5.59.0":
+  version "5.59.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.59.0.tgz#d8b16307c79b821374fa3188d6386a2b4e99811c"
+  integrity sha512-UKbUQO2fmjaTpVMpO6KTLBnhUSN3oQ84ppGAt9H3OaH3zJT4YVgRsgoiSqXGfNf4ufRapJmxEfM9ewxRuXiV0Q==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.58.0":
-  version "5.58.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.58.0.tgz#6590aae0448272872b928fed603ad82b5633e838"
-  integrity sha512-xdHue3Z5/CIUSci799lCvfMiufMJeU6jwS8cA1qn0+eAIem7mXFk249poBKynibZq4CAvGxQHcFjFoZ5VQHWxQ==
+"@frontegg/admin-portal@5.58.1":
+  version "5.58.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.58.1.tgz#f4b30a8c754959f4bf6264d1f13db04f54c8d919"
+  integrity sha512-o7CjWI+22EQss7bRpjvNkllQZn3c6cmTUzTKIEqRXUust2S62nEfH6oUxOeV5cn67RAi2q67tP6wiRDvtzS4EA==
   dependencies:
-    "@frontegg/types" "5.58.0"
+    "@frontegg/types" "5.58.1"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.58.0":
-  version "5.58.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.58.0.tgz#5896d4eabacfa1416c605d6f235a1687683f92c5"
-  integrity sha512-wt4izUNPUTglwpZ2+enqIIxxn/JfLg/Q7U1X7nByn5ul4OWVmValbALFmXr6SI+s3MZ4uKv0rkqhBiCnQIx0jQ==
+"@frontegg/redux-store@5.58.1":
+  version "5.58.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.58.1.tgz#7cc32a9b5b3e547b90b9098fb3b1a4500cb2754f"
+  integrity sha512-stvMKlNkgf0lw7HwBU73nZY6N9ug2nAiJCqvvnU2jCn7oQpPZUMW0cb2B2u9ftsjoiGfIiXKPvM+Cp5wqYBBiA==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.58.0":
-  version "5.58.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.58.0.tgz#62d8c0cbf7f041418c708ad0a5f9971a09455a78"
-  integrity sha512-i8YxdXlvt1no1ACboTgpmPjAH1hWbVdzphVcBFZDHiahDX9N5Yuzz5ndZaqHnU4W2CAKHNLmIjeg/Jm29Vd4fA==
+"@frontegg/types@5.58.1":
+  version "5.58.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.58.1.tgz#ffbdd94be894c2a74e7d98574dbf97112d4fba6c"
+  integrity sha512-MUEM46EvPs8yNTNCEWH0xUD+s8Vq5oXxbtq7M69mtyCJPfRZrXAmN6mWJdJCpF8MJNNjbRyEKRDVEWItqwoPoA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.59.0:
- [FR-7231](https://frontegg.atlassian.net/browse/FR-7231) - remove framer motion - [adacedfc](https://github.com/frontegg/admin-box/pulls?q=adacedfc)

### AdminPortal 5.58.1:
- [FR-7231](https://frontegg.atlassian.net/browse/FR-7231) - login box split improvements - [3db87e14](https://github.com/frontegg/admin-box/pulls?q=3db87e14)
- [FR-7659](https://frontegg.atlassian.net/browse/FR-7659) - Fixes for social login buttons - [bfd27104](https://github.com/frontegg/admin-box/pulls?q=bfd27104)