### PR TITLE
Update Frontegg AdminPortal to 5.59.1

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.59.0",
-    "@frontegg/redux-store": "5.59.0",
+    "@frontegg/admin-portal": "5.59.1",
+    "@frontegg/redux-store": "5.59.1",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.59.0.tgz#926eabae86f58437ddef291a4033c0b3687efc0e"
-  integrity sha512-oqzFQZoOW5el8nTk4QKRf2UYlD3UcEDzdIvJJyxUZORQRkLSZDfV4NWmJs7wRqAG+zJBXDUjDl4OzWrB3qg4dw==
+"@frontegg/admin-portal@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.59.1.tgz#8a83783970377096d375a87f95d873d7befe803b"
+  integrity sha512-O6dTF1DiIFr8hIoqL/RG+CFZBsHTqaVfn+XEU27APds9Rb7259yXYHs9WSA1WNq0lS+EW9bQpf154k+PBQz1Xw==
   dependencies:
-    "@frontegg/types" "5.59.0"
+    "@frontegg/types" "5.59.1"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.59.0.tgz#b84e3cf4bcdf8c8aa7d3379370a175d73d02c324"
-  integrity sha512-P+6peBouvIDkBx4FVF08uY/knws4QBdomwokbZjdI8FUnVqggJ6qE1tftIjtuTIgd7cltKbJoFCEOaSYoGPqnw==
+"@frontegg/redux-store@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.59.1.tgz#a7228fa26c2770185a3354dd77aa57f1a9aa9999"
+  integrity sha512-d8addXvVvmHPyDZk1zncbNFNA8mZRzCq2UR0og8LXGBAUPGb8VB/Zh98jRbGmPj12k2IPjQ4WkCiGz96w6LPsA==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.59.0.tgz#d8b16307c79b821374fa3188d6386a2b4e99811c"
-  integrity sha512-UKbUQO2fmjaTpVMpO6KTLBnhUSN3oQ84ppGAt9H3OaH3zJT4YVgRsgoiSqXGfNf4ufRapJmxEfM9ewxRuXiV0Q==
+"@frontegg/types@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.59.1.tgz#507747a6949ee17b886346f35eb01dc4b2e252e1"
+  integrity sha512-lMj4r4VVWS6bbnP77NvItnE4LrqY6+QfyN7tzazhsbwPMEhec2dikFwTfEw0Ghn/rONTIVDBSRXw1sHGKSDLxA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.59.1:
- [FR-7231](https://frontegg.atlassian.net/browse/FR-7231) - only one testimonial render - [747d7e5d](https://github.com/frontegg/admin-box/pulls?q=747d7e5d)
- [FR-7231](https://frontegg.atlassian.net/browse/FR-7231) - remove wrap page from child signup components - [d45abd29](https://github.com/frontegg/admin-box/pulls?q=d45abd29)