### PR TITLE
Update Frontegg AdminPortal to 5.62.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.61.1",
-    "@frontegg/redux-store": "5.61.1",
+    "@frontegg/admin-portal": "5.62.0",
+    "@frontegg/redux-store": "5.62.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,34 +963,34 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.61.1":
-  version "5.61.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.61.1.tgz#96f634b6df364dfc23bfdf54472fd4269fbaa04c"
-  integrity sha512-a2MqD0bfW3CelVF77pxzg4m1vsJRPXWw8uKDX1KxNcx3PJhsT2NUEYpEzDgmMIdWs8aQPRTpr+EoR2J5KNG++Q==
+"@frontegg/admin-portal@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.62.0.tgz#5dbf1ac27ca18eaa64270c12c56633eddef531d3"
+  integrity sha512-b7Y5PYpfQ62EP84nqu8k5npph6olaVNLXO9wzPDyXTxs4UfIDhX0oYJAuczO8aSiPyjWq0cR9wxNz5YQsc8lXw==
   dependencies:
-    "@frontegg/types" "5.61.1"
+    "@frontegg/types" "5.62.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.61.1":
-  version "5.61.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.61.1.tgz#2bd34777a029af2495b2b77ec5ff676afcc0482c"
-  integrity sha512-C8T+Lb2nIlpRLw58ypPqnyev73AjbTTpymLkdOlFxNrZ6F7QtpR5D7BMSjK35iEhGNpfmD2wi01xvrm63RnVUQ==
+"@frontegg/redux-store@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.62.0.tgz#e1ee6ad70bc43ffed502d15d29773343afa1db1d"
+  integrity sha512-p1LJlo7BhSRNKUYAjBLI+0UcMGmfVAhXvFAWhaQE1LBApq/lQ5atusxVTnAGK9oSt26Q6d7unP/+5YFYS1Do5g==
   dependencies:
-    "@frontegg/rest-api" "^2.10.82"
+    "@frontegg/rest-api" "^2.10.85"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@^2.10.82":
-  version "2.10.83"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.83.tgz#0dd47fdc38d9ac484da0f94b52dec216ad2ecb58"
-  integrity sha512-0CAyrXJ0WgWqoKgvXux4LFKUzvDGHnbjxAGoEtaR29DbqkZaYhRbDcNENuwFswLigG8hob+xAP4gwy1Vyb2K0w==
+"@frontegg/rest-api@^2.10.85":
+  version "2.10.86"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.86.tgz#e0a39acf26e02ad5919a6e4b145a58360f81f6b3"
+  integrity sha512-0rtAZG0lAcn1FWV/q7ud5FgQRPswM+ShnzF7EFb/kF+YwFMmvnhe353fSEM0EsJMzJAr4sGYxksf0t3xRAqkuQ==
 
-"@frontegg/types@5.61.1":
-  version "5.61.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.61.1.tgz#45bb8ef625a7b36fdaea6bcdc187a3d0149daaa2"
-  integrity sha512-ceLkaG+j4DlAgRe7lZqdZDzKzy0CCblFcJpir/t+wZCvwPI5vJrjt2YjGloU8Krup8IpiB7vT4heYGJ3Fyv99g==
+"@frontegg/types@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.62.0.tgz#c7d6b6807ad13d4b27a650a97d177a41bbc5a770"
+  integrity sha512-x8Kx3yle8LeAK0vVJdySlStxWUscYalB8Q8yvFIh5FSXb6OHmotqszxDA3hQyKDIp4e4KKw/2WmQIhwRaq2tWA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.62.0:
- [FR-8053](https://frontegg.atlassian.net/browse/FR-8053) - add user email for mfa recover login saga - [7abb77af](https://github.com/frontegg/admin-box/pulls?q=7abb77af)
- [FR-7231](https://frontegg.atlassian.net/browse/FR-7231) - split mode css bug fix - [38769091](https://github.com/frontegg/admin-box/pulls?q=38769091)