### PR TITLE
Update Frontegg AdminPortal to 5.69.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.68.2",
-    "@frontegg/redux-store": "5.68.2",
+    "@frontegg/admin-portal": "5.68.3",
+    "@frontegg/redux-store": "5.68.3",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.66.1",
-    "@frontegg/redux-store": "5.66.1",
+    "@frontegg/admin-portal": "5.66.2",
+    "@frontegg/redux-store": "5.66.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.68.3",
-    "@frontegg/redux-store": "5.68.3",
+    "@frontegg/admin-portal": "5.69.0",
+    "@frontegg/redux-store": "5.69.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,8 +22,8 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.66.2",
-    "@frontegg/redux-store": "5.66.2",
+    "@frontegg/admin-portal": "5.68.2",
+    "@frontegg/redux-store": "5.68.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.68.3":
-  version "5.68.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.68.3.tgz#74e4c9d85b0b499c731464791a8579b2acda2aa6"
-  integrity sha512-+iupSVn/oQnyX92+zSf4OfZoHOhbmhzPnyiXrjaysn1T4aoFiStXcXGemLBcWvqHd3UV0ybMZ2xERe37Dw7SRg==
+"@frontegg/admin-portal@5.69.0":
+  version "5.69.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.69.0.tgz#dd40a0d013dc7463c3fb528744408e3e7aa6dbe6"
+  integrity sha512-bqaU6f3aOShn3pW5k5pFodab4p3FE3O0bOul8FhmIC92/rsKBIAusZu277bAWMOTVf/zjGK4PU77oXVzqrMhNg==
   dependencies:
-    "@frontegg/types" "5.68.3"
+    "@frontegg/types" "5.69.0"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.68.3":
-  version "5.68.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.68.3.tgz#91613be94506795573bad4b5b36d6ea4caeb3f6c"
-  integrity sha512-BHtrumMcdvrX5KU2malAPPe8R5P7coYmkmlk4ZoMYFvE+gwb21RHXV0ViczAIBVjR2ckJWu0wr8qBrsYqonsQA==
+"@frontegg/redux-store@5.69.0":
+  version "5.69.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.69.0.tgz#7ed356721a27acd48da6092798b75fbb586e0ff6"
+  integrity sha512-NX7/PvBsM226uwwe3QOE5evsOaTYcB/fUrqlMbOzmXA+HO1xIWUIt+XxYxtdomaj8GgfdSOm3yQRnxhYAHYcPg==
   dependencies:
     "@frontegg/rest-api" "^2.10.87"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.89.tgz#fecbd09364b4d35950f527b20721f44b0f7f0dc9"
   integrity sha512-/hrRRhWyNDpzbQ64XPha7jLWWtgYeiBPpE/3w+Cmc81GPPN1nrswCctYv6DNVMs3vD9abp53h9y1ZtFTH3MyBA==
 
-"@frontegg/types@5.68.3":
-  version "5.68.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.68.3.tgz#8a344f76601a5519cc35199ae1f6068a22566f02"
-  integrity sha512-Y70CQezVF1mAzqbNwuH3bahblzZBfAa+VqS56Wwksv6SqBEfk6qbTUc0YxciiyJ1tHn1h1Wem1bkcWVwrleH+Q==
+"@frontegg/types@5.69.0":
+  version "5.69.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.69.0.tgz#c069615dc50093c21494f20c62584795e5df5a56"
+  integrity sha512-ojlq7q5K3RG20CgGf+XAf1iePWjkhyhbSRng9jOKE6ajitbtxkX6EDENqQNJNnTuJpe3Y8uFy7Hy50K/xDnytg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.66.2":
-  version "5.66.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.66.2.tgz#0b514ccae4f9bb4646280e905ed21a78a014d082"
-  integrity sha512-+kifIomPcHKlg9V0It5pnuPaqDnigDHbK0W2blkhwbGsU3iVd3CiB+4RqXq/MbB9V2NhgLGpyZhOcdoZHjvxfg==
+"@frontegg/admin-portal@5.68.2":
+  version "5.68.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.68.2.tgz#c394091bbb6b6c765a7888179e0209020ad2c3ef"
+  integrity sha512-6886CiL+8CHCDgGSQyVIghtULp+DGaRTebC+7XjZtAUKHOjd749wxRO6pff58BVvTBgcD0X2P5bGR4Kx01RFZw==
   dependencies:
-    "@frontegg/types" "5.66.2"
+    "@frontegg/types" "5.68.2"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.66.2":
-  version "5.66.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.66.2.tgz#f8964696d91274a4ed6ce65df1317ff287470f2a"
-  integrity sha512-uNbPm4ulT03Y6AHRb0Ej5ALSJGyZeZm0KckM+o0Gf3kbpn5C1yD0lYKTksFRHt5JXYu+LQAS/X6RkkUc7xl+5Q==
+"@frontegg/redux-store@5.68.2":
+  version "5.68.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.68.2.tgz#3fc0f44e2b13e5e832262dcdd2531609d0c3c09b"
+  integrity sha512-HAv6xnCzRLbQN3JHJG70fibIiKpv+6G9gjJ+UVzDqmZOm6oNokqsXq58jTMmqzXOUaZXt3d5IMUY+ktL7xYDkA==
   dependencies:
     "@frontegg/rest-api" "^2.10.87"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.89.tgz#fecbd09364b4d35950f527b20721f44b0f7f0dc9"
   integrity sha512-/hrRRhWyNDpzbQ64XPha7jLWWtgYeiBPpE/3w+Cmc81GPPN1nrswCctYv6DNVMs3vD9abp53h9y1ZtFTH3MyBA==
 
-"@frontegg/types@5.66.2":
-  version "5.66.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.66.2.tgz#1e62bc3afb39867f268e1631dcb3259be7bfb507"
-  integrity sha512-/gMdZduOUP5UsFM/iNDlz9nS0WQAFPLRcFMV4yJsRC47E2vi2VMnrEZU2dDvBHZIaUs7967VdPRO44rBAxhADw==
+"@frontegg/types@5.68.2":
+  version "5.68.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.68.2.tgz#39bece7e267d38015079764566f1bc8cbde44d0c"
+  integrity sha512-uhR9mWCPMfLY7XD2vlZF4bYYGuDnZk5nn7vrSi+gnHjiMvRWp6Ul6tPOqYXucszh4S3QW3Ksu6mFaxJmlH8TJg==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.66.1":
-  version "5.66.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.66.1.tgz#dcb01ea14aa18731fff9020930eb56cae0679236"
-  integrity sha512-qGbTkj/PUJXhoeZ5UvBXa/CC6gi6PzXdlOrZYnM35vWE0+ifua8i733m9KhPmPepIMjh9ZGKETB8eyjF3avGsg==
+"@frontegg/admin-portal@5.66.2":
+  version "5.66.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.66.2.tgz#0b514ccae4f9bb4646280e905ed21a78a014d082"
+  integrity sha512-+kifIomPcHKlg9V0It5pnuPaqDnigDHbK0W2blkhwbGsU3iVd3CiB+4RqXq/MbB9V2NhgLGpyZhOcdoZHjvxfg==
   dependencies:
-    "@frontegg/types" "5.66.1"
+    "@frontegg/types" "5.66.2"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.66.1":
-  version "5.66.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.66.1.tgz#1891657c3b3708e46801d25a00ddc25d6085c4db"
-  integrity sha512-DVOedXesR6bGKrm0TGPoaqLNH1Y0aBgj7iPwLfuMVjAA9u/JUPmrkCAx/NXgGkwHNDeKn1foVySX2bHmhVbxsg==
+"@frontegg/redux-store@5.66.2":
+  version "5.66.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.66.2.tgz#f8964696d91274a4ed6ce65df1317ff287470f2a"
+  integrity sha512-uNbPm4ulT03Y6AHRb0Ej5ALSJGyZeZm0KckM+o0Gf3kbpn5C1yD0lYKTksFRHt5JXYu+LQAS/X6RkkUc7xl+5Q==
   dependencies:
     "@frontegg/rest-api" "^2.10.87"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.89.tgz#fecbd09364b4d35950f527b20721f44b0f7f0dc9"
   integrity sha512-/hrRRhWyNDpzbQ64XPha7jLWWtgYeiBPpE/3w+Cmc81GPPN1nrswCctYv6DNVMs3vD9abp53h9y1ZtFTH3MyBA==
 
-"@frontegg/types@5.66.1":
-  version "5.66.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.66.1.tgz#048ed5288446c989dc911ba3052bf1859d91c595"
-  integrity sha512-XP7YxSWDgN9tjG7QtQCKS6bQoy91B4NDJ//StS/8aPuEQRmOv+TSYvrzGHKCWzWeNRdS7RYU/QAb5Ib6Nqs1gw==
+"@frontegg/types@5.66.2":
+  version "5.66.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.66.2.tgz#1e62bc3afb39867f268e1631dcb3259be7bfb507"
+  integrity sha512-/gMdZduOUP5UsFM/iNDlz9nS0WQAFPLRcFMV4yJsRC47E2vi2VMnrEZU2dDvBHZIaUs7967VdPRO44rBAxhADw==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,18 +963,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/admin-portal@5.68.2":
-  version "5.68.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.68.2.tgz#c394091bbb6b6c765a7888179e0209020ad2c3ef"
-  integrity sha512-6886CiL+8CHCDgGSQyVIghtULp+DGaRTebC+7XjZtAUKHOjd749wxRO6pff58BVvTBgcD0X2P5bGR4Kx01RFZw==
+"@frontegg/admin-portal@5.68.3":
+  version "5.68.3"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.68.3.tgz#74e4c9d85b0b499c731464791a8579b2acda2aa6"
+  integrity sha512-+iupSVn/oQnyX92+zSf4OfZoHOhbmhzPnyiXrjaysn1T4aoFiStXcXGemLBcWvqHd3UV0ybMZ2xERe37Dw7SRg==
   dependencies:
-    "@frontegg/types" "5.68.2"
+    "@frontegg/types" "5.68.3"
     uuid "^8.3.2"
 
-"@frontegg/redux-store@5.68.2":
-  version "5.68.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.68.2.tgz#3fc0f44e2b13e5e832262dcdd2531609d0c3c09b"
-  integrity sha512-HAv6xnCzRLbQN3JHJG70fibIiKpv+6G9gjJ+UVzDqmZOm6oNokqsXq58jTMmqzXOUaZXt3d5IMUY+ktL7xYDkA==
+"@frontegg/redux-store@5.68.3":
+  version "5.68.3"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.68.3.tgz#91613be94506795573bad4b5b36d6ea4caeb3f6c"
+  integrity sha512-BHtrumMcdvrX5KU2malAPPe8R5P7coYmkmlk4ZoMYFvE+gwb21RHXV0ViczAIBVjR2ckJWu0wr8qBrsYqonsQA==
   dependencies:
     "@frontegg/rest-api" "^2.10.87"
     "@reduxjs/toolkit" "^1.5.0"
@@ -987,10 +987,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.89.tgz#fecbd09364b4d35950f527b20721f44b0f7f0dc9"
   integrity sha512-/hrRRhWyNDpzbQ64XPha7jLWWtgYeiBPpE/3w+Cmc81GPPN1nrswCctYv6DNVMs3vD9abp53h9y1ZtFTH3MyBA==
 
-"@frontegg/types@5.68.2":
-  version "5.68.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.68.2.tgz#39bece7e267d38015079764566f1bc8cbde44d0c"
-  integrity sha512-uhR9mWCPMfLY7XD2vlZF4bYYGuDnZk5nn7vrSi+gnHjiMvRWp6Ul6tPOqYXucszh4S3QW3Ksu6mFaxJmlH8TJg==
+"@frontegg/types@5.68.3":
+  version "5.68.3"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.68.3.tgz#8a344f76601a5519cc35199ae1f6068a22566f02"
+  integrity sha512-Y70CQezVF1mAzqbNwuH3bahblzZBfAa+VqS56Wwksv6SqBEfk6qbTUc0YxciiyJ1tHn1h1Wem1bkcWVwrleH+Q==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.69.0:
- [FR-8377](https://frontegg.atlassian.net/browse/FR-8377) - fix mfa bug on speedy login - [1ea01020](https://github.com/frontegg/admin-box/pulls?q=1ea01020)
- [FR-8363](https://frontegg.atlassian.net/browse/FR-8363) - Fix cypress removing videos - [6ec7e647](https://github.com/frontegg/admin-box/pulls?q=6ec7e647)

### AdminPortal 5.68.3:
- [FR-8356](https://frontegg.atlassian.net/browse/FR-8356) - fix country selcet width - [2962fbd4](https://github.com/frontegg/admin-box/pulls?q=2962fbd4)

### AdminPortal 5.68.2:
- [FR-8363](https://frontegg.atlassian.net/browse/FR-8363) - Fix upgrading admin portal in angular and next js - [3191a16f](https://github.com/frontegg/admin-box/pulls?q=3191a16f)

### AdminPortal 5.66.2:
- [FR-8260](https://frontegg.atlassian.net/browse/FR-8260) - add next js repo to the release pipeline to upgrade admin portal version automatically - [e272ce07](https://github.com/frontegg/admin-box/pulls?q=e272ce07)