### PR TITLE
Update Frontegg AdminPortal to 6.2.4

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.2.3",
+    "@frontegg/js": "6.2.4",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,18 +970,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.2.3.tgz#9d6f07f6fa8689751b8fde338f4e83421b87c4d4"
-  integrity sha512-KAwUYRLqkov5+1j5+xkdr5TREa+Buf2PhEfCaN8eviAINwtFY0pFkTlc20gUDI1cN7rk/iycddfwN+GO3vcPyA==
+"@frontegg/js@6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.2.4.tgz#b46ac4b10d0035c019142c2f73c240d0f765ec0e"
+  integrity sha512-HWhnZ8MS4rYGy2W7mqlXTC1LEqMYrRaWMfmmi018Do1tLx5WnCdNoKnIL5xiP3yFoZMgQt7a7NYklJEMkP1NsA==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/types" "6.2.3"
+    "@frontegg/types" "6.2.4"
 
-"@frontegg/redux-store@6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.3.tgz#7c554b1b2be965868b4b248beb3722b821b62f0e"
-  integrity sha512-vzjsm+MK6Qo/V5R6TgWGPz8OgLgpYCvESxztALOvsJkRYDyMhZJuboJyFNUQb+2Qeo3YRhAsDikgHoPNd0YkJw==
+"@frontegg/redux-store@6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.4.tgz#0f3d6ddf07e572c484cba6a2ff93f991d3a21e44"
+  integrity sha512-ELn3K+RxQFW00Fotk3ICxriHdBm1RZccSUCc19BMrkCJJjcjy+g1774GAhDE761ZIQTnwP+HTyFvzBQFtAD6Fw==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/rest-api" "3.0.11"
@@ -996,13 +996,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.3.tgz#fa1bc5449f30fb3238b532148a2d68345db915e0"
-  integrity sha512-A9OtBZzX2hkEz1AuRLrQMM1rHAz+LJGLRHX1gixjyi8BteOBdScwu5ziGU/pJ1iDNykXTvdZqXp/38I0BQwe/Q==
+"@frontegg/types@6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.4.tgz#40a65d9aa8d611d4adb934980774d1983ef1774c"
+  integrity sha512-9D00JVoVSpqX7rpBNd3zakhKX/9AH8JG1qALIpp8BVzfHouwZV1zMHZTdCEKhJGvvgXPDI+FWozQ/gEuX+7enQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.2.3"
+    "@frontegg/redux-store" "6.2.4"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.2.4:
- [FR-8882](https://frontegg.atlassian.net/browse/FR-8882) - Make sure to show touch id in speedy login on the builder preview for all users - [eb36dc64](https://github.com/frontegg/admin-box/pulls?q=eb36dc64)
- [FR-8956](https://frontegg.atlassian.net/browse/FR-8956) - fix user management permissions - [417ed973](https://github.com/frontegg/admin-box/pulls?q=417ed973)