### PR TITLE
Update Frontegg AdminPortal to 6.5.1

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config build/rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.5.0",
+    "@frontegg/js": "6.5.1",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,18 +977,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.5.0.tgz#939dee7771722d5d13b153834ba5e66c97b0d5fe"
-  integrity sha512-LP/c7iQfe7NjOjvCgs73bwg6Qyv5Jj2K41hJ+/Mff7URu/SuUEzquUjhELJbUU48VSEpJa19HivxOyXR3b224Q==
+"@frontegg/js@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.5.1.tgz#8f8b7b2eb582f317338591096b9c03519887cc93"
+  integrity sha512-CugtQhVGyLgcgTX/8hJEXH1KsO/ZzanhxUR+PrflmAxqWkh2KFRMRDx7FFPJz3vLIL4VdwwX5oVhGbK4usXU4g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.5.0"
+    "@frontegg/types" "6.5.1"
 
-"@frontegg/redux-store@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.5.0.tgz#8d05872f4ee4d1dd47276725004f5d7078bf9902"
-  integrity sha512-hNX0X2YS96uFElcgBcXvLPCIxjQHo8O1SpN5cia4tQnHK43E8VBWPInNmwfV9ZedmtH7E1ZHNwf2hy08WnVL8A==
+"@frontegg/redux-store@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.5.1.tgz#9cb4813eb1d8cb0ba02257adae8ca70aa2d0eebb"
+  integrity sha512-iIRXTomE5+wNyVXyadZoFPyY4Izc1JQNouHhGoDh762S9TSD2gfzGQa5dixEZbJALurh1/RBZIJjGAFItuQO8A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.25"
@@ -1003,13 +1003,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.5.0.tgz#f31c0e99e817c23c21cab1bbb07fcd4934ac723e"
-  integrity sha512-Wj+Ps3r0UApwoeBpOQbBwsqZ39WTWg7tGUbuzZBGukBqLFwxIZGuTnhaZH973wmyrLW/BJlhZG1lO+dBEsodLA==
+"@frontegg/types@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.5.1.tgz#c0adda8e9bb613051553a995bdb91f37a0180d92"
+  integrity sha512-g2IMSF/FzwCju36ILKa1d/QeJUtwuwFDyGBEvGliQPLOBXa360FYVm4wOXbhZHP1thrJYXCl4tll2jF51W1wwg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.5.0"
+    "@frontegg/redux-store" "6.5.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.5.1:
- [FR-8221](https://frontegg.atlassian.net/browse/FR-8221) - fix use effect - [73ef31e9](https://github.com/frontegg/admin-box/pulls?q=73ef31e9)
- [FR-8917](https://frontegg.atlassian.net/browse/FR-8917) - login with password mfa tests - [db5a05a8](https://github.com/frontegg/admin-box/pulls?q=db5a05a8)
- [FR-8912](https://frontegg.atlassian.net/browse/FR-8912) - FR-8911 - personal tokens and user tabs tests - [e0bf4332](https://github.com/frontegg/admin-box/pulls?q=e0bf4332)
- [FR-8913](https://frontegg.atlassian.net/browse/FR-8913) - audit-logs-tests - [c455a220](https://github.com/frontegg/admin-box/pulls?q=c455a220)
- [FR-8914](https://frontegg.atlassian.net/browse/FR-8914) - api tokens tests - [ba000de2](https://github.com/frontegg/admin-box/pulls?q=ba000de2)