### PR TITLE
Update Frontegg AdminPortal to 6.9.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.8.2",
+    "@frontegg/js": "6.9.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.8.1",
+    "@frontegg/js": "6.8.2",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,18 +977,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.2.tgz#5925e95d8d89b9392a86be3787db78410754f488"
-  integrity sha512-IEk6x2ZrRJGVqiwH1RJNpmuPa9hXZHvSOUWRPgCIyy8xtrH3XgUkEwNbEdv9QfG0RbhJcyGe5uD3Oh9XFHWOxg==
+"@frontegg/js@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.9.0.tgz#05e0c9fd3decc4271af568cec6ca9a659271109f"
+  integrity sha512-pE5GhgMtbwKyJaA/gHSFsKl6fa6ClL2EBKTuRJvAqN5hTnjxUiMc13NdL2KcPqG+jnvK+qz2om6Z4/t4bK3cgQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.8.2"
+    "@frontegg/types" "6.9.0"
 
-"@frontegg/redux-store@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.2.tgz#4d4aa63ad7735a3940f2dbbb6d267b9ad271677c"
-  integrity sha512-50qMR2wxx0TBo+Ve74AxBx6eUiCyxJBYmZfLd8JQXGmZOYxNyeWtdOMrYRe6M/mJQi52TDKXZDS74gislfNTUQ==
+"@frontegg/redux-store@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.9.0.tgz#67e042c978e69fd5e9f09c275e5fb2be30af3c68"
+  integrity sha512-qbfgrj2IKPsa/LnPFjSpsKy5yC0I9aGWWlhmKkmsP5ZezdskhVDKFlTQEXpDwHHQc/KUrw/0LBjziI3QEp6Q6w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.26"
@@ -1003,13 +1003,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.8.2":
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.2.tgz#5271752c908dc665aa06cca4db09de18c6dec825"
-  integrity sha512-+GkRM+5NZNgXvdePIC/7DL4yOR3fxa84OFFFQZe3JFN45jgoHzwSpiK/IK3UW6u1bfNkHb1N4wq7VureGsYRDQ==
+"@frontegg/types@6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.9.0.tgz#0dd5a8d92848c97393d0f8ea69ad2d335d8c325c"
+  integrity sha512-Twx2H1oyS15V98Dl6kP1u8x/4D4+qls17j+UwaZFBKsBfkD3J1Wd4I1segRuOGWzzoRqFsEClLkfBzqgVnsBrw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.8.2"
+    "@frontegg/redux-store" "6.9.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,18 +977,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.1.tgz#4998cb40ed84412cded17f364dffb15b834dca27"
-  integrity sha512-S9Pz4hYGXNUGsHboqnxK63US8yNXaYUO7P2lZISFzXD/0ifgwfBXafXXrZO3NWNGBhwr151rgFnxQBz1FRAk4A==
+"@frontegg/js@6.8.2":
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.8.2.tgz#5925e95d8d89b9392a86be3787db78410754f488"
+  integrity sha512-IEk6x2ZrRJGVqiwH1RJNpmuPa9hXZHvSOUWRPgCIyy8xtrH3XgUkEwNbEdv9QfG0RbhJcyGe5uD3Oh9XFHWOxg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.8.1"
+    "@frontegg/types" "6.8.2"
 
-"@frontegg/redux-store@6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.1.tgz#e199e4b6a5091e42fbe97cfedea45736cddb981c"
-  integrity sha512-3ArBUnTqdnGtXwLC+c5q0KZfzNzBYCSxXokyHyEckBgmYMQL4+fuCkRr2LFJZ/9YLQIAthfElKb+3uevomLbfA==
+"@frontegg/redux-store@6.8.2":
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.8.2.tgz#4d4aa63ad7735a3940f2dbbb6d267b9ad271677c"
+  integrity sha512-50qMR2wxx0TBo+Ve74AxBx6eUiCyxJBYmZfLd8JQXGmZOYxNyeWtdOMrYRe6M/mJQi52TDKXZDS74gislfNTUQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.26"
@@ -1003,13 +1003,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.8.1":
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.1.tgz#4348e74250c687a2e2c4ecb0752e94229560c3f9"
-  integrity sha512-w5srGzLmoGoD8/KElY4GRIBub0LBYDeXiDJR5fDi3svTVyLFjtKaoRyR1A0WvlOCWtY4N9PIzR1xwvO2/dPOMg==
+"@frontegg/types@6.8.2":
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.8.2.tgz#5271752c908dc665aa06cca4db09de18c6dec825"
+  integrity sha512-+GkRM+5NZNgXvdePIC/7DL4yOR3fxa84OFFFQZe3JFN45jgoHzwSpiK/IK3UW6u1bfNkHb1N4wq7VureGsYRDQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.8.1"
+    "@frontegg/redux-store" "6.8.2"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.9.0:
- [FR-9157](https://frontegg.atlassian.net/browse/FR-9157) - Display an alert when the user has not provided base url option - [5686fa47](https://github.com/frontegg/admin-box/pulls?q=5686fa47)
- [FR-9153](https://frontegg.atlassian.net/browse/FR-9153) - make sure to clear interval and event listener router - [f278bc9b](https://github.com/frontegg/admin-box/pulls?q=f278bc9b)
- [FR-9151](https://frontegg.atlassian.net/browse/FR-9151) - Render github button label as GitHub instead of Github - [9bfb4f15](https://github.com/frontegg/admin-box/pulls?q=9bfb4f15)

### AdminPortal 6.8.2:
- [FR-9147](https://frontegg.atlassian.net/browse/FR-9147) - Make sure to not set doc title if login box rendered in builder mode - [6734f56c](https://github.com/frontegg/admin-box/pulls?q=6734f56c)