### PR TITLE
Update Frontegg AdminPortal to 6.59.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.58.0",
+    "@frontegg/js": "6.59.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.54.0",
+    "@frontegg/js": "6.55.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.55.0",
+    "@frontegg/js": "6.56.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.53.0",
+    "@frontegg/js": "6.54.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.56.0",
+    "@frontegg/js": "6.57.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.57.0",
+    "@frontegg/js": "6.58.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.53.0":
-  version "6.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.53.0.tgz#0a1e275fc10d86fec337e710d9a4dd15be41624d"
-  integrity sha512-DFJxE3HQlpWh1WCjxKbK71WEdDAVNhKQKR8uXNgsiKk8dtof21yZiaVG2pN8Tn2iDe34vv5BoK5e2UzNXBxOsw==
+"@frontegg/js@6.54.0":
+  version "6.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.54.0.tgz#f7ce19ba665af9fa9c30c674b8ba73669bd7ae17"
+  integrity sha512-heAgz1Q/IUCBjbbDPVHvikskuFml6N/EVGvvlzzc8X4HZZ6ZHW0ueSEMxUSqEUyqa6SPUMf5kyXryrVVSg9KTw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.53.0"
+    "@frontegg/types" "6.54.0"
 
-"@frontegg/redux-store@6.53.0":
-  version "6.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.53.0.tgz#ddcbd68a6cdd64ee6e8987e5bb83ebf8fd8e78d4"
-  integrity sha512-RAyowKn1r65kZ8wS+KBW/SdDkWQZoZnTghgxfQrzIl/sVQ5Irgj+OUO7o/B558DBXQwaCjXmACejXm56unTApQ==
+"@frontegg/redux-store@6.54.0":
+  version "6.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.54.0.tgz#c50e925dd37018072e255063c6e4fd6ce1a81cc1"
+  integrity sha512-UD1xk6RORbXPyinNoRc1pHaGV6DSLraibfwBTzk7Cqw9dDuDFONUFgCJjgmq0vO8T+p8GnTxKk6icCPX266brA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.52"
@@ -1870,13 +1870,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.53.0":
-  version "6.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.53.0.tgz#f7f02e3bf0a3f262534c037314227a519da11dd0"
-  integrity sha512-G9ZuM9UrOaBfv3lbXTmhTC/RMxBEKWf/ZSPDfH8LJEN8C/xeuM4Jo3inGuzjlSZ0ocaUqFp3DOOI+PuLuP6mOw==
+"@frontegg/types@6.54.0":
+  version "6.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.54.0.tgz#464ff38d34db8ed17313fdb8228ae41095437506"
+  integrity sha512-ezI2TQ3/D2qhFDwqRkDhul7CRuuoeYpxG3NxqyBSkfB8Vz3YXMJ8MG9Y4m3cvCW19xEHSPk/eagYjYvqo2+Z5g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.53.0"
+    "@frontegg/redux-store" "6.54.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,39 +1844,39 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.58.0":
-  version "6.58.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.58.0.tgz#af56e76b572b2e6b97519d026a4e722df6539d97"
-  integrity sha512-x9pH+SzcBvfpvECyiqH4y9tISwN3Vufy+8PxK1FwWzSF/sKDRYD2J7uoUmayIJL2Vd/COBpKeMuKm3vxMK4dDQ==
+"@frontegg/js@6.59.0":
+  version "6.59.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.59.0.tgz#7523a37ca2794f2b109467f8aacb3aeb5dacef0b"
+  integrity sha512-DGwsiStWl6QEm7bg/jDrySzin2/AtaVhMoeLYEsNrIqyFEILGDHIwNgBApXj3EhGlGI8VTC7cEF92WTUmOuXIQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.58.0"
+    "@frontegg/types" "6.59.0"
 
-"@frontegg/redux-store@6.58.0":
-  version "6.58.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.58.0.tgz#4bdbf2b5706476a4d366b5a1fe672c86176eadd4"
-  integrity sha512-l7w2ZVKa8WjlclVydLVx3WwH+7o9dbV3JmDVigp9G1gzTuI604tbrSeXUVWmTwNmopPlZ8maTKGWMXXeizauLw==
+"@frontegg/redux-store@6.59.0":
+  version "6.59.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.59.0.tgz#94459b022520903aed11c74f1b7f639c85067dd6"
+  integrity sha512-PMaLD+dtpeXHOLaMw7/zj5HMD/ytUc46llgH+R6E93KRUm/9HeCjeeJgV790rvAQPMKGyKmnJydr8rk85CEvSA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.54"
+    "@frontegg/rest-api" "^3.0.58"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.54":
-  version "3.0.54"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.54.tgz#6e81c73a7dcd8dd7c99506d3f25d2c213e658e86"
-  integrity sha512-YERdszxyYrSpg7I/7dr5obPQ1sGp6E8Ok7H8q3yOn0BlS5UDH/b0mD8NDb3lE71U47lVj74tDKwZLNMIctoEkA==
+"@frontegg/rest-api@^3.0.58":
+  version "3.0.60"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.60.tgz#9c009edc1e6ab446266a1a95fba4c273a4aa0ca8"
+  integrity sha512-mv4E8ASWntWz+63cPbcV23cxrTtlsID9ptvHFMEB4SnEzz+jOJyYV4LFwmjBfFTKDSDfqH4Pxur2TbdlMVP4Zg==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.58.0":
-  version "6.58.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.58.0.tgz#7d2607a364f746e2a2437daa71f4e1cd16c4ddcf"
-  integrity sha512-QprNIzjCE8fCK0lGNYqPIW+cA8N9A5UJsAWRzRMwc1xFCwdhWtzTXGt2XBhjkrtzrP/O9oxuZEErSw/F7U09fw==
+"@frontegg/types@6.59.0":
+  version "6.59.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.59.0.tgz#906855962d277a39281ad2a8d3a984a66103e2d7"
+  integrity sha512-heBxuXUZaK53sBeW04XV9qsy3l1AwVnZxVxKAvF4Ld3vy4QpSy7BWemfeNYl/vPJTXAIMtQUH7jt+icT5to72w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.58.0"
+    "@frontegg/redux-store" "6.59.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,39 +1844,39 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.55.0":
-  version "6.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.55.0.tgz#a2ce728090ada4da72c282ed73e213bdbf047621"
-  integrity sha512-7TMtXSF+DVSTNh8aefaWvHAEPQtFX+kfq5t9GUDUTtaDqmjZpIX/FuddA3goEnRmfNNNs4qkqx1LcCq3sxdfDg==
+"@frontegg/js@6.56.0":
+  version "6.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.56.0.tgz#2085c53be8aac1defab59cfd4fbf52889ab01236"
+  integrity sha512-tb05Yd7kAYXl/Y5eOUwbkmC1spd5KEiBGke+3XR42j+HkNXzoK8egKx48SUb93e+XvL3U1NLjY1yCkhasglPSw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.55.0"
+    "@frontegg/types" "6.56.0"
 
-"@frontegg/redux-store@6.55.0":
-  version "6.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.55.0.tgz#6bd40169fe681e41ef38d7e15f4f5073c005cc06"
-  integrity sha512-MbES8ijeYnTEm9jjoF4DmjjYs2rnoZHenaFQUBq4i8oMem39Qv04RRzm55zUIvb7gXf8UIT93dXjlgO0aaeSow==
+"@frontegg/redux-store@6.56.0":
+  version "6.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.56.0.tgz#c8496c63ae9c1592a6c9bbda347ff39a5f5e7f4d"
+  integrity sha512-RLhK6Q9lv/nReWKzDqMuqJIU2xmd9PmaMGUITncEHzgcTtIaDoMVXyGPODgnBy0iiswBg5hec4H7AlLvYJCMOg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.53"
+    "@frontegg/rest-api" "^3.0.54"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.53":
-  version "3.0.53"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.53.tgz#32d907c8f3344b88ab25c90dba2eb4577d9fc238"
-  integrity sha512-s68mKq3016jTcBVpuPcrSR0P92guqoGGxCw+qmU0V3k5bwxP9lW9H8PXoXP0OxBUc1TSnrWnqyHbbs8Miivssw==
+"@frontegg/rest-api@^3.0.54":
+  version "3.0.54"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.54.tgz#6e81c73a7dcd8dd7c99506d3f25d2c213e658e86"
+  integrity sha512-YERdszxyYrSpg7I/7dr5obPQ1sGp6E8Ok7H8q3yOn0BlS5UDH/b0mD8NDb3lE71U47lVj74tDKwZLNMIctoEkA==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.55.0":
-  version "6.55.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.55.0.tgz#25f23629a2098f90e85219bae56ba4d168f2fb8c"
-  integrity sha512-n1IDrHS4WbORrusO7FeZ8xKOANCRH4y3dX6LUFdwy74BRbdnlARAesFEjaL1sJ9JM0aTctygz0vhnvOoBcFP2w==
+"@frontegg/types@6.56.0":
+  version "6.56.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.56.0.tgz#22b1930dd900a965caeaf41dcf4269e34c6dff4b"
+  integrity sha512-5I0AOWj8IYtdJvqP+Ve4OACEEjMIh7jV+UEWGfG1rkgDOr7V7GdPAUmkjzvT2cMomG5jUbMd/kpctiUREt/C5g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.55.0"
+    "@frontegg/redux-store" "6.56.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.56.0":
-  version "6.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.56.0.tgz#2085c53be8aac1defab59cfd4fbf52889ab01236"
-  integrity sha512-tb05Yd7kAYXl/Y5eOUwbkmC1spd5KEiBGke+3XR42j+HkNXzoK8egKx48SUb93e+XvL3U1NLjY1yCkhasglPSw==
+"@frontegg/js@6.57.0":
+  version "6.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.57.0.tgz#fc4db9ee72b60eed1bc7b6ff8a5849dab44b5184"
+  integrity sha512-iLQEK50wVTN98guPtrgNAW6V2a3Qk6nNDxaZbQMbSMMNgNYAlU1zY62iu3V1Ztv409cN6emLz6xDmolGHYfTKA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.56.0"
+    "@frontegg/types" "6.57.0"
 
-"@frontegg/redux-store@6.56.0":
-  version "6.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.56.0.tgz#c8496c63ae9c1592a6c9bbda347ff39a5f5e7f4d"
-  integrity sha512-RLhK6Q9lv/nReWKzDqMuqJIU2xmd9PmaMGUITncEHzgcTtIaDoMVXyGPODgnBy0iiswBg5hec4H7AlLvYJCMOg==
+"@frontegg/redux-store@6.57.0":
+  version "6.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.57.0.tgz#b1dbe02a84fd54e8932a809003fc1bf5de7a017b"
+  integrity sha512-mSFmS/seFLo9n8HhcSF1d4A1kcOXYcAjvJ9Yf0MuULYroYcZxvWHy1B7mr0iWz9xn/cAjg5cHSKR8SH+6IvIoA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.54"
@@ -1870,13 +1870,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.56.0":
-  version "6.56.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.56.0.tgz#22b1930dd900a965caeaf41dcf4269e34c6dff4b"
-  integrity sha512-5I0AOWj8IYtdJvqP+Ve4OACEEjMIh7jV+UEWGfG1rkgDOr7V7GdPAUmkjzvT2cMomG5jUbMd/kpctiUREt/C5g==
+"@frontegg/types@6.57.0":
+  version "6.57.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.57.0.tgz#bc90479c46f9334ff4f9cb2227356d1acfdc18db"
+  integrity sha512-fL/fNaPA39EAQwbiNOhtDd+8bj3+m/xEp0VgQXb2EeApKlaCKmO8FiBe/EJKjPcapNjraUGaaWPBFa/cGNF44Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.56.0"
+    "@frontegg/redux-store" "6.57.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,39 +1844,39 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.54.0":
-  version "6.54.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.54.0.tgz#f7ce19ba665af9fa9c30c674b8ba73669bd7ae17"
-  integrity sha512-heAgz1Q/IUCBjbbDPVHvikskuFml6N/EVGvvlzzc8X4HZZ6ZHW0ueSEMxUSqEUyqa6SPUMf5kyXryrVVSg9KTw==
+"@frontegg/js@6.55.0":
+  version "6.55.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.55.0.tgz#a2ce728090ada4da72c282ed73e213bdbf047621"
+  integrity sha512-7TMtXSF+DVSTNh8aefaWvHAEPQtFX+kfq5t9GUDUTtaDqmjZpIX/FuddA3goEnRmfNNNs4qkqx1LcCq3sxdfDg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.54.0"
+    "@frontegg/types" "6.55.0"
 
-"@frontegg/redux-store@6.54.0":
-  version "6.54.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.54.0.tgz#c50e925dd37018072e255063c6e4fd6ce1a81cc1"
-  integrity sha512-UD1xk6RORbXPyinNoRc1pHaGV6DSLraibfwBTzk7Cqw9dDuDFONUFgCJjgmq0vO8T+p8GnTxKk6icCPX266brA==
+"@frontegg/redux-store@6.55.0":
+  version "6.55.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.55.0.tgz#6bd40169fe681e41ef38d7e15f4f5073c005cc06"
+  integrity sha512-MbES8ijeYnTEm9jjoF4DmjjYs2rnoZHenaFQUBq4i8oMem39Qv04RRzm55zUIvb7gXf8UIT93dXjlgO0aaeSow==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.52"
+    "@frontegg/rest-api" "^3.0.53"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.52":
-  version "3.0.52"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.52.tgz#c29baed132eeab9110c8b28a6cebf8dd425b2737"
-  integrity sha512-Ne3gnDEhN3EkYPrNqHBaIc/ETrd2N/AeP/xYq5+usLlAbCCjMgjTBHZGYCh9HChhKb0P6xhzfFf19Q1LwL2mDg==
+"@frontegg/rest-api@^3.0.53":
+  version "3.0.53"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.53.tgz#32d907c8f3344b88ab25c90dba2eb4577d9fc238"
+  integrity sha512-s68mKq3016jTcBVpuPcrSR0P92guqoGGxCw+qmU0V3k5bwxP9lW9H8PXoXP0OxBUc1TSnrWnqyHbbs8Miivssw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.54.0":
-  version "6.54.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.54.0.tgz#464ff38d34db8ed17313fdb8228ae41095437506"
-  integrity sha512-ezI2TQ3/D2qhFDwqRkDhul7CRuuoeYpxG3NxqyBSkfB8Vz3YXMJ8MG9Y4m3cvCW19xEHSPk/eagYjYvqo2+Z5g==
+"@frontegg/types@6.55.0":
+  version "6.55.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.55.0.tgz#25f23629a2098f90e85219bae56ba4d168f2fb8c"
+  integrity sha512-n1IDrHS4WbORrusO7FeZ8xKOANCRH4y3dX6LUFdwy74BRbdnlARAesFEjaL1sJ9JM0aTctygz0vhnvOoBcFP2w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.54.0"
+    "@frontegg/redux-store" "6.55.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.57.0":
-  version "6.57.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.57.0.tgz#fc4db9ee72b60eed1bc7b6ff8a5849dab44b5184"
-  integrity sha512-iLQEK50wVTN98guPtrgNAW6V2a3Qk6nNDxaZbQMbSMMNgNYAlU1zY62iu3V1Ztv409cN6emLz6xDmolGHYfTKA==
+"@frontegg/js@6.58.0":
+  version "6.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.58.0.tgz#af56e76b572b2e6b97519d026a4e722df6539d97"
+  integrity sha512-x9pH+SzcBvfpvECyiqH4y9tISwN3Vufy+8PxK1FwWzSF/sKDRYD2J7uoUmayIJL2Vd/COBpKeMuKm3vxMK4dDQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.57.0"
+    "@frontegg/types" "6.58.0"
 
-"@frontegg/redux-store@6.57.0":
-  version "6.57.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.57.0.tgz#b1dbe02a84fd54e8932a809003fc1bf5de7a017b"
-  integrity sha512-mSFmS/seFLo9n8HhcSF1d4A1kcOXYcAjvJ9Yf0MuULYroYcZxvWHy1B7mr0iWz9xn/cAjg5cHSKR8SH+6IvIoA==
+"@frontegg/redux-store@6.58.0":
+  version "6.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.58.0.tgz#4bdbf2b5706476a4d366b5a1fe672c86176eadd4"
+  integrity sha512-l7w2ZVKa8WjlclVydLVx3WwH+7o9dbV3JmDVigp9G1gzTuI604tbrSeXUVWmTwNmopPlZ8maTKGWMXXeizauLw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.54"
@@ -1870,13 +1870,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.57.0":
-  version "6.57.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.57.0.tgz#bc90479c46f9334ff4f9cb2227356d1acfdc18db"
-  integrity sha512-fL/fNaPA39EAQwbiNOhtDd+8bj3+m/xEp0VgQXb2EeApKlaCKmO8FiBe/EJKjPcapNjraUGaaWPBFa/cGNF44Q==
+"@frontegg/types@6.58.0":
+  version "6.58.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.58.0.tgz#7d2607a364f746e2a2437daa71f4e1cd16c4ddcf"
+  integrity sha512-QprNIzjCE8fCK0lGNYqPIW+cA8N9A5UJsAWRzRMwc1xFCwdhWtzTXGt2XBhjkrtzrP/O9oxuZEErSw/F7U09fw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.57.0"
+    "@frontegg/redux-store" "6.58.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-10112 -  update admin box pipeline for next js and angular
- FR-10248 - mfa spacing
- FR-10256 - replace apple button redirect url
- FR-10248 - add tooltip for card list item
- FR-10248 - mfa fixes
- FR-10246 - Add impersonation indication in login session table

- FR-10275 - Avoid calling conditioned hook in Google onetap code

- FR-9413 - fix main login validation for on boarding
- FR-10241 - added support for redirectUrl on prelogin
- FR-10240 - remove linkedin from inactive providers

- FR-9983 - make sure that OTC fields are in one column with submit button
- FR-9642 - Logout on OAuth service on Hosted Login
- FR-8022 - support linkedin
- FR-10212 - hide disabled cards from mfa list

- FR-10162 - added support for google one tap
- FR-9983 - Improve digits component
- FR-9987 - fix social btns UI
- FR-9413 - Login, unified behaviour 

- FR-10047 - fix bad UI webhook
- FR-9993 - Add custom event to add user by bulk
- FR-10118 - fix apple logo color change when font color changes
- FR-9976 - refactor otc