### PR TITLE
Update Frontegg AdminPortal to 6.68.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.67.0",
+    "@frontegg/js": "6.68.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.66.0",
+    "@frontegg/js": "6.67.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,39 +1844,39 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.66.0":
-  version "6.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.66.0.tgz#35a64657de80bf8de9d17a9beb03cb46c8260ee1"
-  integrity sha512-4ak+CWf0UI1PZlto80dxrZhzL1fU06pKpwW708gv9Vf+avno+o2W2fWRb4YjbvscMZRziWhk4Z7FfBnjtCI42w==
+"@frontegg/js@6.67.0":
+  version "6.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.67.0.tgz#ddd8d242842160a35c55ca5071befae607883f1e"
+  integrity sha512-gQCk0LR6MlbfIOgvYLJ/Oh2vl04zo3F/OJ6NBupDwko1KEqHOS+h+nrIw22KD6AW1j3A3mzehd7n44ivKizoEw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.66.0"
+    "@frontegg/types" "6.67.0"
 
-"@frontegg/redux-store@6.66.0":
-  version "6.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.66.0.tgz#ad2eac3ad24b712098b3a3fdf7ae1f2589a2cb34"
-  integrity sha512-avlnfbHD20RAtBEavXEr2cI974njAEPJLv2/bj9oiTtx+QjqNcOFPxVZm7PziKaQfs6uz+SoIdo7rnqoteCxMw==
+"@frontegg/redux-store@6.67.0":
+  version "6.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.67.0.tgz#3ece62bce3cc6570d8ae94d3c9c772168320dab4"
+  integrity sha512-b+RRE1MuCJLL1yIEoagEoC0ZcCHAedW4xBPjGbarYA9fV3GaC7NqXJ3WQA73pzkYKyBM8dqnJ83rnZ5rcBGUdA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.70"
+    "@frontegg/rest-api" "3.0.71"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.70":
-  version "3.0.70"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.70.tgz#0f516c56fc1330ef01c547064bec86b4c5b58325"
-  integrity sha512-aLt1zitaFqGlcITuNpE/0Vb6MhQ1syCOVgaSR9oitUfpEiiIt4L1H0zhH1DTv3CKf5PdZV7hYAtK7ByLuW2s8Q==
+"@frontegg/rest-api@3.0.71":
+  version "3.0.71"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.71.tgz#87c3379563143786a67127cbb4965f6147b203ea"
+  integrity sha512-cMWi2jc/YM5v9osF5ofkXgIygZjgs4OiS+eOQUTwDvpOqkwJSpZ9T0r1r6E1YgOA3yFMPONBA8hrC4HUXeKHIg==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.66.0":
-  version "6.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.66.0.tgz#99e8db95db517a532c25201e75ef2b519218207d"
-  integrity sha512-2vX1jueGbnvt8Es+B03U7hjDud2Kb2xgxyT9Get5bAJLzcT+Zusa5tP4JVgCEPwW4zil6HIRiZ9IEgHGsiEaMA==
+"@frontegg/types@6.67.0":
+  version "6.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.67.0.tgz#3fa0980bbd12297128de88018bcdc16f546df521"
+  integrity sha512-Mus6W5c6KfhUnsk4FSa0n4WPDJSFJq67WpC8jpvo2jYDh2u7MQm67zouGrkprdkSjhMWIeNdkQHQY1rpoNdAug==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.66.0"
+    "@frontegg/redux-store" "6.67.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.67.0":
-  version "6.67.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.67.0.tgz#ddd8d242842160a35c55ca5071befae607883f1e"
-  integrity sha512-gQCk0LR6MlbfIOgvYLJ/Oh2vl04zo3F/OJ6NBupDwko1KEqHOS+h+nrIw22KD6AW1j3A3mzehd7n44ivKizoEw==
+"@frontegg/js@6.68.0":
+  version "6.68.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.68.0.tgz#b5535a4775b12f71e02ca8587dcf15254f51d272"
+  integrity sha512-xw4CcF1qRNFZPwxECr3KXjUKQaGUDhkots6iRzlA2jHaN+BGUv5zenbKKsFQic3R9DWbIDj180DcZbag2qPWzA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.67.0"
+    "@frontegg/types" "6.68.0"
 
-"@frontegg/redux-store@6.67.0":
-  version "6.67.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.67.0.tgz#3ece62bce3cc6570d8ae94d3c9c772168320dab4"
-  integrity sha512-b+RRE1MuCJLL1yIEoagEoC0ZcCHAedW4xBPjGbarYA9fV3GaC7NqXJ3WQA73pzkYKyBM8dqnJ83rnZ5rcBGUdA==
+"@frontegg/redux-store@6.68.0":
+  version "6.68.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.68.0.tgz#fb05719cfa0de77574b1131ba9bcbbb312ebb627"
+  integrity sha512-azUiakpesbC9fcmTOQl57pojin1sVefh9j5ZXiscwxrobi8WtyLCm3ciZo/xD4zITOg+3uYDPx5vAiKFp9pgbQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.71"
@@ -1870,13 +1870,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.67.0":
-  version "6.67.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.67.0.tgz#3fa0980bbd12297128de88018bcdc16f546df521"
-  integrity sha512-Mus6W5c6KfhUnsk4FSa0n4WPDJSFJq67WpC8jpvo2jYDh2u7MQm67zouGrkprdkSjhMWIeNdkQHQY1rpoNdAug==
+"@frontegg/types@6.68.0":
+  version "6.68.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.68.0.tgz#85723a5a94c6d7b829937c9f1d17166f2313ce51"
+  integrity sha512-I6ycunr1a3R1XjfDO5BvYPBrt6cegKfBBZKwjOulOeOAqrnf1Xo9LrT+yxExn1GqPZy4HtmcOlgOvCGE6IpmIA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.67.0"
+    "@frontegg/redux-store" "6.68.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- 

- FR-10485 - Update restapi version
- FR-10017 - add email type to all email inputs
- FR-10501 - Fix mobile width of login box
- FR-10196 - Fix scroll in privacy page
- FR-10489 - update scim ui
- FR-10483 - Added the option to customize forget password button
- FR-10374 - improve values ui in split mode
- FR-10184 - add access tokens
- FR-9995 - Accept Invitation text and icon change