### PR TITLE
Update Frontegg AdminPortal to 6.88.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.86.0",
+    "@frontegg/js": "6.87.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.87.0",
+    "@frontegg/js": "6.88.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.87.0":
-  version "6.87.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.87.0.tgz#185abde76c00d161736bf991f3a9123aff071f32"
-  integrity sha512-f6T9OsP+0cZij4p9b6PJ+lBssOw5vW34TWsy616vVt12xaClOEl5jnQVQVhcS4o2fSydv8g+p67cPFGA8cathQ==
+"@frontegg/js@6.88.0":
+  version "6.88.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.88.0.tgz#ea26e026536289884bb581da8e4b897b90bd5ff0"
+  integrity sha512-plR6PHFDJ/mSTQq5IYCkIKmqTpB812QGQBa6Q8IlIsXS76pfUCufezA5L3+dBMoY02UtHsO4XhJ1XXf7vXlWyA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.87.0"
+    "@frontegg/types" "6.88.0"
 
-"@frontegg/redux-store@6.87.0":
-  version "6.87.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.87.0.tgz#70f11309c2d21fbf1547efe70477beab16723479"
-  integrity sha512-QhcoOD7fyqXvoApjqsA9Na5RkLdie1LQRuUWm0NkJtEDDPE2CxLfm1sdyAInGFRRRTWcixU+5tRPHSHYZuWEpw==
+"@frontegg/redux-store@6.88.0":
+  version "6.88.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.88.0.tgz#fa8b3f5356131d63f67756c48830b8fcf494a677"
+  integrity sha512-j1tMsyQT9wbOlox60nWndwPLpYHNOfx7F0Qx5aLdu7BYh/hWwNqr6D/HC+72ecHveRYH7IoHCQ/V/wIIuTk9Nw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.95"
@@ -1871,13 +1871,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.87.0":
-  version "6.87.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.87.0.tgz#88b8ead7d5f3e4539962bd03cb3c145b82f50195"
-  integrity sha512-o7WBvYoqaxod9baPhH6jLF8hpSxoKvVlphCx1xdilC/sqPst4OjNdbGq4iw8ubUaDPa9u5UvxbL6Jjo7hjZ1rg==
+"@frontegg/types@6.88.0":
+  version "6.88.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.88.0.tgz#0a49cfdc11c6aa377647a0c0e17e86e385bab032"
+  integrity sha512-Utamkki4tUFvNUEglWXq6Rap8UJWgfmx3ktoX78ZXoOVUsj4qnoW7gk9ayYpktq7dV4tdCbwAo5N3jXso7GoEw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.87.0"
+    "@frontegg/redux-store" "6.88.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.86.0":
-  version "6.86.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.86.0.tgz#17672c9c8929ac357210922ff40ed9f1ee182d97"
-  integrity sha512-pwSHxyzbv3M4wfrCunt5qYrSRGn8of/93lUBAosIGuj9TUMaKeBtYh7dBaBkdg2W/LbEcE6byNxP+EK4uLzXvQ==
+"@frontegg/js@6.87.0":
+  version "6.87.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.87.0.tgz#185abde76c00d161736bf991f3a9123aff071f32"
+  integrity sha512-f6T9OsP+0cZij4p9b6PJ+lBssOw5vW34TWsy616vVt12xaClOEl5jnQVQVhcS4o2fSydv8g+p67cPFGA8cathQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.86.0"
+    "@frontegg/types" "6.87.0"
 
-"@frontegg/redux-store@6.86.0":
-  version "6.86.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.86.0.tgz#9d1fb11312850c98f5fdf0a7670d3c76423df069"
-  integrity sha512-rJ/zHni5BOb6S/keQR4L7vmB+a/InZ+DRnIc2SPQp62UqyU6XRJXdCrPz79u/Kjdfw8CPqd7FIw9+uTym8iIfA==
+"@frontegg/redux-store@6.87.0":
+  version "6.87.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.87.0.tgz#70f11309c2d21fbf1547efe70477beab16723479"
+  integrity sha512-QhcoOD7fyqXvoApjqsA9Na5RkLdie1LQRuUWm0NkJtEDDPE2CxLfm1sdyAInGFRRRTWcixU+5tRPHSHYZuWEpw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "^3.0.95"
@@ -1871,13 +1871,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.86.0":
-  version "6.86.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.86.0.tgz#57f3e1371df230d87504a46d83eed55ec2fd92a6"
-  integrity sha512-CxRJpYcR6OLmq/hUCiu//+ACWlAHbGW3TlH4QSyDfdKsPoQ6K2OAmo4oyeELMAOGbIpRN492n/Zyh0oZwYhVjA==
+"@frontegg/types@6.87.0":
+  version "6.87.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.87.0.tgz#88b8ead7d5f3e4539962bd03cb3c145b82f50195"
+  integrity sha512-o7WBvYoqaxod9baPhH6jLF8hpSxoKvVlphCx1xdilC/sqPst4OjNdbGq4iw8ubUaDPa9u5UvxbL6Jjo7hjZ1rg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.86.0"
+    "@frontegg/redux-store" "6.87.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-11393 - Extract customization options from App.tsx for better usage
- FR-11063 - add tests for passkeys
- FR-11351 - preserve query params for login per tenant

- FR-11389 - Fix activate account button disable/loading state