### PR TITLE
Update Frontegg AdminPortal to 6.96.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.95.0",
+    "@frontegg/js": "6.96.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,39 +1844,39 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.95.0":
-  version "6.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.95.0.tgz#65d68d0ca7c2319699d5ba457b1fced35c0212cb"
-  integrity sha512-xav+cdaopyKPJrlKRxVa9EA60mvfmxDVAsrLH9+NPmlmPjnpiMV4nKfc99a9mOKBzXo9WbZJ5UzK0gO2Q8e+0w==
+"@frontegg/js@6.96.0":
+  version "6.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.96.0.tgz#849d9d67bd345f94644aea8e3559cf62f8a3f4ca"
+  integrity sha512-2VRmf9cFu+WIwdcALgJxjdB/BXFWaUjCZwW3TJo6vQafS9jZRLzfQdIN1ev+lRgDpJ+9nZR5yYOnz+6kNNGPbg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.95.0"
+    "@frontegg/types" "6.96.0"
 
-"@frontegg/redux-store@6.95.0":
-  version "6.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.95.0.tgz#6333eafa51de18b9abe8d73c4d2cc3f8d25430fb"
-  integrity sha512-P6wW85jMSxBXwD5DrKEn4frKN3C9i5aukjusbe19v+vI5mI3HGx5Di0yBBzkQbHk0gxC7OBtAxTHJYgHOuduIw==
+"@frontegg/redux-store@6.96.0":
+  version "6.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.96.0.tgz#e641de5d99bed7f0ea082d87ee35f645721b1a6a"
+  integrity sha512-vF6sCr7oahE20qnQVQYn2XjbDtgrm77JRAClL0nOaGGyl85oTP+/5obE/XKSJ74+SI1rW89R9iE0UStwnV6Ccg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.96"
+    "@frontegg/rest-api" "^3.0.98"
     "@reduxjs/toolkit" "1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.96":
-  version "3.0.96"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.96.tgz#eaf12023371bb4f48506d5af56f2f635e2759f89"
-  integrity sha512-+4JRDzcYC+uag9RYvj5GfLaA9WObQrweeZ8jnmwm7rYjY0CgZCRDoU+C/v3pqLksDZlEQfudsN9rueeChW0WOA==
+"@frontegg/rest-api@^3.0.98":
+  version "3.0.100"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.100.tgz#fbb6112ccb52c4d2b944a766c75517dcf4374a3d"
+  integrity sha512-vLl5fBmHbl8A7GJQyqwUPXcRWslQ65FJX4jpeTUxKHma8Nta5KtVvhQwnUF6Ws9UCn+QPal0sRSJ7NOMJnP6Lw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.95.0":
-  version "6.95.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.95.0.tgz#80fcc8392c05212dab272799ffafeaabb2908812"
-  integrity sha512-HUWRwHgo7KIrb9RM73szHOSJx6a4PgWd2+nTJcFawLHE7ooz0+Ah8OyYiV0zKRoU4VlhgBdW705o87LW8wca5g==
+"@frontegg/types@6.96.0":
+  version "6.96.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.96.0.tgz#2669e458e40d03adaa8a9f78b18cbec4d8518936"
+  integrity sha512-swHiies8IPfkase4zPJYHDaWt7kUkKZIws470MjmiGmld6WZhJlRy/GKPTyzgajeLwzONaHefKeVhZ0iVETW0Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.95.0"
+    "@frontegg/redux-store" "6.96.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-11442 - multiple sso cleanup
- FR-11657 - login per tenant api new
- FR-11718 - fix users table
- FR-11113 - fix frontegg logo bug
- FR-11442 - SSO and provisioning split
- FR-11617 - a11y fix enter key issue
- FR-11656 - login per tenant self service UI
- FR-11352 - nested table
- [Snyk] Security upgrade @azure/storage-blob from 12.11.0 to 12.13.0