### PR TITLE
FR-12055 - entitlements - allow data access

### DIFF
--- a/packages/vue/src/auth/interfaces.ts
+++ b/packages/vue/src/auth/interfaces.ts
@@ -11,6 +11,7 @@ import {
   SocialLoginState,
   SSOState,
   TeamState,
+  EntitlementsState
 } from '@frontegg/redux-store';
 import VueRouter from 'vue-router';
 import { TenantsState } from '@frontegg/redux-store';
@@ -75,6 +76,7 @@ declare module 'vue/types/vue' {
     fronteggAuth: FronteggAuthService;
     loginWithRedirect: () => void;
     mapAuthState: () => { authState: AuthState };
+    mapEntitlementsState: () => { entitlements: EntitlementsState['entitlements'] };
     mapLoginState: () => { loginState: LoginState };
     mapAcceptInvitationState: () => { acceptInvitationState: AcceptInvitationState };
     mapActivateAccountState: () => { activateState: ActivateAccountState };

--- a/packages/vue/src/auth/mapAuthState.ts
+++ b/packages/vue/src/auth/mapAuthState.ts
@@ -16,6 +16,8 @@ import {
   TeamActions,
   TenantsActions,
   AuthActions,
+  getEntitlements,
+  Entitlements
 } from '@frontegg/redux-store';
 import { ActionsHolder } from './ActionsHolder';
 import { AuthState, EnhancedStore } from '@frontegg/redux-store';
@@ -23,6 +25,7 @@ import { FronteggAuthService } from './service';
 import VueRouter from 'vue-router';
 import {
   authStateKey,
+  entitlementsStateKey,
   fronteggAuthKey,
   fronteggLoadedKey,
   fronteggOptionsKey,
@@ -125,6 +128,16 @@ export const useFronteggLoaded = () => {
   const fronteggLoaded = inject(fronteggLoadedKey) as boolean;
 
   return fronteggLoaded;
+};
+
+/**
+  @param keys The requested entitlement keys
+  @returns Entitlements contain true/false for every key (state of is key entitled)
+*/
+export const useEntitlements = (keys: string[]): Entitlements => {
+  const entitlements = inject(entitlementsStateKey) || {};
+
+  return getEntitlements(entitlements, keys);
 };
 
 export const useUnsubscribeFronteggStore = () => {

--- a/packages/vue/src/auth/mapAuthState.ts
+++ b/packages/vue/src/auth/mapAuthState.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { inject, onUpdated, onMounted, reactive, onBeforeUnmount } from 'vue';
+import { inject, onUpdated, onMounted, reactive, onBeforeUnmount, computed } from 'vue';
 import { defaultGetterGenerator, objectMappers } from '../helpers';
 import {
   AcceptInvitationActions,
@@ -25,7 +25,6 @@ import { FronteggAuthService } from './service';
 import VueRouter from 'vue-router';
 import {
   authStateKey,
-  entitlementsStateKey,
   fronteggAuthKey,
   fronteggLoadedKey,
   fronteggOptionsKey,
@@ -132,12 +131,18 @@ export const useFronteggLoaded = () => {
 
 /**
   @param keys The requested entitlement keys
-  @returns Entitlements contain true/false for every key (state of is key entitled)
+  @returns Entitlements contain state data for every key (inc if entitled)
 */
 export const useEntitlements = (keys: string[]): Entitlements => {
-  const entitlements = inject(entitlementsStateKey) || {};
+  const authState = inject(authStateKey);
 
-  return getEntitlements(entitlements, keys);
+  return computed(() =>
+    getEntitlements(authState.entitlementsState?.entitlements || {}, keys)
+      .reduce((entitlementsResult, { isEntitled }, i) => ({
+        ...entitlementsResult,
+        [keys[i]]: isEntitled
+      }), {})
+  );
 };
 
 export const useUnsubscribeFronteggStore = () => {

--- a/packages/vue/src/auth/mapAuthState.ts
+++ b/packages/vue/src/auth/mapAuthState.ts
@@ -41,6 +41,7 @@ const mapSubState = (statePrefix: string, propertyName?: string) =>
   };
 
 export const mapAuthState = (_this: any) => mapSubState('auth', 'authState').bind(_this);
+export const mapEntitlementsState = (_this: any) => mapSubState('auth.entitlementsState.entitlements', 'entitlements').bind(_this);
 export const mapLoginState = (_this: any) => mapSubState('auth.loginState').bind(_this);
 export const mapAcceptInvitationState = (_this: any) => mapSubState('auth.acceptInvitationState').bind(_this);
 export const mapActivateAccountState = (_this: any) => mapSubState('auth.activateState').bind(_this);
@@ -58,6 +59,7 @@ export const mapTenantsState = (_this: any) => mapSubState('auth.tenantsState').
 export const connectMapState = (_this: any) => {
   Object.assign(_this, {
     mapAuthState: mapAuthState(_this),
+    mapEntitlementsState: mapEntitlementsState(_this),
     mapLoginState: mapLoginState(_this),
     mapAcceptInvitationState: mapAcceptInvitationState(_this),
     mapActivateAccountState: mapActivateAccountState(_this),
@@ -140,7 +142,9 @@ export const useEntitlements = (keys: string[]): Entitlements => {
     getEntitlements(authState.entitlementsState?.entitlements || {}, keys)
       .reduce((entitlementsResult, { isEntitled }, i) => ({
         ...entitlementsResult,
-        [keys[i]]: isEntitled
+        [keys[i]]: {
+          isEntitled
+        }
       }), {})
   );
 };

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -6,6 +6,7 @@ export const FRONTEGG_LOADER_UNSUBSCRIBE = 'FRONTEGG_LOADER_UNSUBSCRIBE';
 
 export const fronteggLoadedKey = Symbol('fronteggLoade');
 export const authStateKey = Symbol('authState');
+export const entitlementsStateKey = Symbol('entitlementsState');
 export const unsubscribeFronteggStoreKey = Symbol('unsubscribeFronteggStore');
 export const fronteggAuthKey = Symbol('fronteggAuth');
 export const routerKey = Symbol('router');

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -18,7 +18,6 @@ import { connectMapState, connectFronteggStoreV3 } from './auth/mapAuthState';
 import { ContextHolder, FronteggFrameworks } from '@frontegg/rest-api';
 import {
   authStateKey,
-  entitlementsStateKey,
   fronteggAuthKey,
   fronteggLoadedKey,
   fronteggOptionsKey,
@@ -209,8 +208,6 @@ const Frontegg: PluginObject<PluginOptions> | any = {
 
       // @ts-ignore
       Vue.provide(authStateKey, authState);
-      // @ts-ignore
-      Vue.provide(entitlementsStateKey, authState.entitlementsState?.entitlements);
       // @ts-ignore
       Vue.provide(unsubscribeFronteggStoreKey, unsubscribe);
       // @ts-ignore

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -228,7 +228,8 @@ const Frontegg: PluginObject<PluginOptions> | any = {
         setStoreKey(this, store);
         this.fronteggAuth = Vue.fronteggAuth;
         this.loginWithRedirect = loginWithRedirect.bind(this);
-        this.getEntitlements = fronteggApp.getEntitlements.bind(fronteggApp);
+        // _entitlements was added for hack purposes - we want the user to pass it to have a reactive part in the computed property, then it will get updated
+        this.getEntitlements = (_entitlements: any, keys: string[]) => fronteggApp.getEntitlements(keys);
         connectMapState(this);
       },
       updated() {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -18,6 +18,7 @@ import { connectMapState, connectFronteggStoreV3 } from './auth/mapAuthState';
 import { ContextHolder, FronteggFrameworks } from '@frontegg/rest-api';
 import {
   authStateKey,
+  entitlementsStateKey,
   fronteggAuthKey,
   fronteggLoadedKey,
   fronteggOptionsKey,
@@ -45,6 +46,7 @@ export {
   mapTeamActions,
   useAuthState,
   useUnsubscribeFronteggStore,
+  useEntitlements,
   useFronteggLoaded,
   useFrontegg,
   useFronteggAuthGuard,
@@ -208,6 +210,8 @@ const Frontegg: PluginObject<PluginOptions> | any = {
       // @ts-ignore
       Vue.provide(authStateKey, authState);
       // @ts-ignore
+      Vue.provide(entitlementsStateKey, authState.entitlementsState?.entitlements);
+      // @ts-ignore
       Vue.provide(unsubscribeFronteggStoreKey, unsubscribe);
       // @ts-ignore
       Vue.provide(fronteggAuthKey, fronteggAuthReactive);
@@ -227,6 +231,7 @@ const Frontegg: PluginObject<PluginOptions> | any = {
         setStoreKey(this, store);
         this.fronteggAuth = Vue.fronteggAuth;
         this.loginWithRedirect = loginWithRedirect.bind(this);
+        this.getEntitlements = fronteggApp.getEntitlements.bind(fronteggApp);
         connectMapState(this);
       },
       updated() {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -15,7 +15,7 @@ import { StoreHolder } from './StoreHolder';
 import { AdminPortal, initialize } from '@frontegg/js';
 import { FronteggAuthService } from './auth/service';
 import { connectMapState, connectFronteggStoreV3 } from './auth/mapAuthState';
-import { ContextHolder, FronteggFrameworks } from '@frontegg/rest-api';
+import { ContextHolder, FronteggFrameworks, EntitlementsResponse } from '@frontegg/rest-api';
 import {
   authStateKey,
   fronteggAuthKey,
@@ -228,8 +228,8 @@ const Frontegg: PluginObject<PluginOptions> | any = {
         setStoreKey(this, store);
         this.fronteggAuth = Vue.fronteggAuth;
         this.loginWithRedirect = loginWithRedirect.bind(this);
-        // _entitlements was added for hack purposes - we want the user to pass it to have a reactive part in the computed property, then it will get updated
-        this.getEntitlements = (_entitlements: any, keys: string[]) => fronteggApp.getEntitlements(keys);
+        // _entitlements was added for to make the computed property reactive, then it will get updated
+        this.getEntitlements = (_entitlements: EntitlementsResponse, keys: string[]) => fronteggApp.getEntitlements(keys);
         connectMapState(this);
       },
       updated() {

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,5 +1,6 @@
 import { EnhancedStore } from '@reduxjs/toolkit';
 import { Unsubscribe } from 'redux';
+import { FronteggApp } from '@frontegg/js';
 import { FronteggPluginService } from './interfaces';
 
 declare module 'vue/types/vue' {
@@ -16,5 +17,11 @@ declare module 'vue/types/vue' {
     _data?: any;
     fronteggLoaded: boolean;
     loginWithRedirect: () => void;
+
+    /**
+      @param keys The requested entitlement keys
+      @returns Entitlements contain true/false for every key (state of is key entitled)
+    */
+    getEntitlements: FronteggApp['getEntitlements'];
   }
 }

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,6 +1,6 @@
 import { EnhancedStore } from '@reduxjs/toolkit';
 import { Unsubscribe } from 'redux';
-import { FronteggApp } from '@frontegg/js';
+import { Entitlements } from '@frontegg/redux-store';
 import { FronteggPluginService } from './interfaces';
 
 declare module 'vue/types/vue' {
@@ -19,9 +19,10 @@ declare module 'vue/types/vue' {
     loginWithRedirect: () => void;
 
     /**
+      @param _entitlements
       @param keys The requested entitlement keys
       @returns Entitlements contain true/false for every key (state of is key entitled)
     */
-    getEntitlements: FronteggApp['getEntitlements'];
+    getEntitlements: (_entitlements: any, keys: string[]) => Entitlements;
   }
 }


### PR DESCRIPTION
Pay attention to the hack in Vue 2 implementation.

**Vue 3:**

Implemented by inject & provide mechanism.

```vue
<template>
  <div>
    <p>Feature 1 (vue 3): {{entitlements['feature-1'].isEntitled ? 'on' : 'off'}}</p>
    <p>Feature 2 (vue 3): {{entitlements['feature-2'].isEntitled ? 'on' : 'off'}}</p>
  </div>
</template>

<script>

import { useEntitlements } from '@frontegg/vue';

export default {
  setup() {
    const entitlements = useEntitlements(['feature-1', 'feature-2']);

    return {
      entitlements
    };
  },
};
</script>
```

**Vue2:** 

I don't like the way I implemented this. Sending the entitlements from the computed property is a hack to start a recomputation. I didn't find another way to mark the function as reactive in Vue 2.

```vue
<template>
  <div>
    <p>Feature 1 (vue 2): {{this.myEntitlements.isFeature1Ent ? 'on' : 'off'}}</p>
    <p>Feature 2 (vue 2): {{this.myEntitlements.isFeature2Ent ? 'on' : 'off'}}</p>
  </div>
</template>

<script lang="ts">
  import Vue from 'vue';
  import { Entitlements } from '@frontegg/types';
  
  export default Vue.extend({
    name: 'HelloWorld',
    data() {
      return {
        ...this.mapEntitlementsState()
      };
    },    
    computed: {
      myEntitlements() {
        const [
          { isEntitled: isFeature1Ent },
          { isEntitled: isFeature2Ent }
        ]: Entitlements = this.getEntitlements(this.entitlements, ['feature-1', 'feature-2']);

        return {
          isFeature1Ent,
          isFeature2Ent,
        };
      }
    },
  });
</script>
```
