### PR TITLE
Update Frontegg AdminPortal to 6.119.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.118.0",
+    "@frontegg/js": "6.119.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.116.0",
+    "@frontegg/js": "6.118.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.118.0":
-  version "6.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.118.0.tgz#d4fc49a83781efdb87389acad3d53882b49ed458"
-  integrity sha512-IKvWUw1dEr747SYMK5GuBt0pGWWLpPMmnzixmlb/Lme/03i+TTSFFfD9dqWwOR6KiFfBLl+3XPfjbH0EI/ElCw==
+"@frontegg/js@6.119.0":
+  version "6.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.119.0.tgz#1b1b0c8f6301b79bd71ffb2c79a7a141f5ede4ef"
+  integrity sha512-DVfw6oEzlEI6UvupcKY9wB3eXG9u4VdJ2f6kncdzMrpxGxP+8E3mUfVFYGsODd77smp8DcLitnERNyV+BBU8/g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.118.0"
+    "@frontegg/types" "6.119.0"
 
-"@frontegg/redux-store@6.118.0":
-  version "6.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.118.0.tgz#5bbfbf8e87153807e6f62f277d8525cd38d4b4a0"
-  integrity sha512-t937Qri/eG4mqATZWtHsxuXFcIwjNRhS7P6fF1qloeL+JGr09DchpLJHWpPurIdztyRkQIQmN8wMMefpHEaUVg==
+"@frontegg/redux-store@6.119.0":
+  version "6.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.119.0.tgz#d4e05b91b9861ca00d1c50041c9871f7f2539a0e"
+  integrity sha512-0vvamVBHgSf50+kTFIE6CoNgKmlI60b79Nb0Nu5FM/Wg/KINqBa49I0KP98W8YXKORQjGIzvGZvVxGemEHz8mg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.136"
@@ -1871,13 +1871,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.118.0":
-  version "6.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.118.0.tgz#4cdcfd8044081746a15d0ae1722c24b3e4d1970b"
-  integrity sha512-IJYhVT4ea0eMvftAgmjv2z+kBcG134mi4SMhW+Gp1PuxRC/2XDqMHSus/7w+b7Hb9T3NPpRSLcyOUeP7oDQstA==
+"@frontegg/types@6.119.0":
+  version "6.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.119.0.tgz#a3bd8ee20fc1c7d2e7be7b1d91d93f359ed32030"
+  integrity sha512-qVjW34hpOjxXI1rthSF6+Ao4VPAEl2Sn9hXqSFXQKid97dZkAhJkhg/rXnZCn632cqiLHAKGJZ3PpHd+NX8h8Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.118.0"
+    "@frontegg/redux-store" "6.119.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,39 +1844,40 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.116.0":
-  version "6.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.116.0.tgz#6aa1e3d2db43f75fb2c710414b9d7a5ef847e214"
-  integrity sha512-NR3+j34TZkMRCJHW52EKcc+iVQy78vuaqvlMz6coEjwVLoypLywa1dSdC518g5Aayk0xvKxj9JH5YYmgDCKaoA==
+"@frontegg/js@6.118.0":
+  version "6.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.118.0.tgz#d4fc49a83781efdb87389acad3d53882b49ed458"
+  integrity sha512-IKvWUw1dEr747SYMK5GuBt0pGWWLpPMmnzixmlb/Lme/03i+TTSFFfD9dqWwOR6KiFfBLl+3XPfjbH0EI/ElCw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.116.0"
+    "@frontegg/types" "6.118.0"
 
-"@frontegg/redux-store@6.116.0":
-  version "6.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.116.0.tgz#c1c750bcbe712c2280962d695069ca02710bf36a"
-  integrity sha512-OGlf9JITbjpgg39MFr82lbi4tJDXcV/DzbcVRAW4+tSCHO7jDGslNxNqvXxpCNrG7UObbsqyf/hHCrEkT2pxpQ==
+"@frontegg/redux-store@6.118.0":
+  version "6.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.118.0.tgz#5bbfbf8e87153807e6f62f277d8525cd38d4b4a0"
+  integrity sha512-t937Qri/eG4mqATZWtHsxuXFcIwjNRhS7P6fF1qloeL+JGr09DchpLJHWpPurIdztyRkQIQmN8wMMefpHEaUVg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.0.127"
+    "@frontegg/rest-api" "3.0.136"
     "@reduxjs/toolkit" "1.8.5"
+    fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.127":
-  version "3.0.127"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.127.tgz#44c75ad68f3adcb35975d2628c09f5caedcf70e8"
-  integrity sha512-YArJB29W66MXzI0Z1ttzJnuldrTWPdlsCe3IsW9Fc4I4DDxKPNz/e3aJjWXLNlWn1DMuRvg1NoQ/RubVnas39A==
+"@frontegg/rest-api@3.0.136":
+  version "3.0.136"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.136.tgz#45c0758ea03fd45123cf2be4a6dd14eb587185c5"
+  integrity sha512-Cvr5v36XUrm15XIJ0YptBKSCo1W0INX+UDznjgZfqrWJsbX2xB5ue13yrGPINxvBpixL7D3IlNPtafq/1bnBGA==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.116.0":
-  version "6.116.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.116.0.tgz#6c8f1e069c1d58ff34a7a995518ef1db92814dbf"
-  integrity sha512-IsYvaAtS8+Yfdpgxv8CaKbcdFoNqvInlJudzRWwjAMYWTCGVJovbxJS6nZA+baP8hnqyaDyrTHfgnkvk+OY9Wg==
+"@frontegg/types@6.118.0":
+  version "6.118.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.118.0.tgz#4cdcfd8044081746a15d0ae1722c24b3e4d1970b"
+  integrity sha512-IJYhVT4ea0eMvftAgmjv2z+kBcG134mi4SMhW+Gp1PuxRC/2XDqMHSus/7w+b7Hb9T3NPpRSLcyOUeP7oDQstA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.116.0"
+    "@frontegg/redux-store" "6.118.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 
@@ -7575,7 +7576,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
- FR-12628 - fix custom login with hosted oauth in URL 
- FR-12536 - check up card component
- FR-12535 - security severity badge component
- FR-12543 - msp fix bulk users invitation
- FR-12575 - change remember my device default value
- FR-12550 - Align all auth methods to get login response of me and tenants from auth APIs
- FR-12313 - fix cdn nextjs alpha version

- FR-12586 - Fix pipeline
[FR-12581 - add support for custom inline html and script]
[FR-12343 - admin box implement sso per tenant]
[FR-12488 - users page load users support v1 and v2]
[FR-12164 - MSP bulk user invitation]
[FR-12479 - msp fix warning dialog issue]
[FR-12408 - entitlements redesign]