### PR TITLE
FR-12190 - entitlements implementation

### DIFF
--- a/packages/vue/src/auth/entitlements.ts
+++ b/packages/vue/src/auth/entitlements.ts
@@ -1,0 +1,44 @@
+// @ts-ignore
+import { inject, computed } from 'vue';
+import { EntitledToOptions, Entitlement } from '@frontegg/types';
+
+import {
+  getFeatureEntitlements,
+  getPermissionEntitlements,
+  getEntitlements,
+  AuthState,
+} from '@frontegg/redux-store';
+
+import { authStateKey } from '../constants';
+
+const getEntitlementsState = () => {
+  const authState = inject(authStateKey) as AuthState;
+  return authState.user?.entitlements;
+};
+
+/**
+  @param key feature
+  @returns if the user is entitled to the given feature. Attaching the justification if not
+  @throws when entitlement is not enabled via frontegg options
+*/
+export const useFeatureEntitlements = (key: string): Entitlement => {
+  return computed(() => getFeatureEntitlements(getEntitlementsState(), key));
+};
+
+/**
+  @param key permission
+  @returns if the user is entitled to the given permission. Attaching the justification if not
+  @throws when entitlement is not enabled via frontegg options
+*/    
+export const usePermissionEntitlements = (key: string): Entitlement => {
+  return computed(() => getPermissionEntitlements(getEntitlementsState(), key));
+};
+
+/**
+  @param options - including permission or feature key
+  @returns if the user is entitled to the given permission or feature. Attaching the justification if not
+  @throws when entitlement is not enabled via frontegg options
+*/
+export const useEntitlements = (entitledToOptions: EntitledToOptions): Entitlement => {
+  return computed(() => getEntitlements(getEntitlementsState(), entitledToOptions));
+};

--- a/packages/vue/src/auth/entitlements.ts
+++ b/packages/vue/src/auth/entitlements.ts
@@ -35,7 +35,7 @@ export const usePermissionEntitlements = (key: string): Entitlement => {
 };
 
 /**
-  @param options - including permission or feature key
+  @param entitledToOptions - including permission or feature key
   @returns if the user is entitled to the given permission or feature. Attaching the justification if not
   @throws when entitlement is not enabled via frontegg options
 */

--- a/packages/vue/src/auth/interfaces.ts
+++ b/packages/vue/src/auth/interfaces.ts
@@ -11,6 +11,7 @@ import {
   SocialLoginState,
   SSOState,
   TeamState,
+  User
 } from '@frontegg/redux-store';
 import VueRouter from 'vue-router';
 import { TenantsState } from '@frontegg/redux-store';
@@ -75,6 +76,7 @@ declare module 'vue/types/vue' {
     fronteggAuth: FronteggAuthService;
     loginWithRedirect: () => void;
     mapAuthState: () => { authState: AuthState };
+    mapEntitlementsState: () => { entitlements: User['entitlements'] };
     mapLoginState: () => { loginState: LoginState };
     mapAcceptInvitationState: () => { acceptInvitationState: AcceptInvitationState };
     mapActivateAccountState: () => { activateState: ActivateAccountState };

--- a/packages/vue/src/auth/mapAuthState.ts
+++ b/packages/vue/src/auth/mapAuthState.ts
@@ -29,6 +29,7 @@ import {
   fronteggStoreKey,
   routerKey,
   unsubscribeFronteggStoreKey,
+  loadEntitlementsKey,
 } from '../constants';
 
 const mapSubState = (statePrefix: string, propertyName?: string) =>
@@ -39,6 +40,7 @@ const mapSubState = (statePrefix: string, propertyName?: string) =>
   };
 
 export const mapAuthState = (_this: any) => mapSubState('auth', 'authState').bind(_this);
+export const mapEntitlementsState = (_this: any) => mapSubState('auth.user.entitlements', 'entitlements').bind(_this);
 export const mapLoginState = (_this: any) => mapSubState('auth.loginState').bind(_this);
 export const mapAcceptInvitationState = (_this: any) => mapSubState('auth.acceptInvitationState').bind(_this);
 export const mapActivateAccountState = (_this: any) => mapSubState('auth.activateState').bind(_this);
@@ -56,6 +58,7 @@ export const mapTenantsState = (_this: any) => mapSubState('auth.tenantsState').
 export const connectMapState = (_this: any) => {
   Object.assign(_this, {
     mapAuthState: mapAuthState(_this),
+    mapEntitlementsState: mapEntitlementsState(_this),
     mapLoginState: mapLoginState(_this),
     mapAcceptInvitationState: mapAcceptInvitationState(_this),
     mapActivateAccountState: mapActivateAccountState(_this),
@@ -149,11 +152,17 @@ export const useFronteggAuth = () => {
   return fronteggAuth;
 };
 
+export const useLoadEntitlements = () => {
+  const loadEntitlements = inject(loadEntitlementsKey);
+  return loadEntitlements;
+};
+
 export const useFrontegg = () => {
   const fronteggLoaded = useFronteggLoaded();
   const unsubscribeFronteggStore = useUnsubscribeFronteggStore();
   const authState = useAuthState();
   const fronteggAuth = useFronteggAuth();
+  const loadEntitlements = useLoadEntitlements();
 
   const fronteggStore = useFronteggStore() as EnhancedStore;
 
@@ -174,6 +183,7 @@ export const useFrontegg = () => {
     authState,
     fronteggAuth,
     loginWithRedirect,
+    loadEntitlements
   };
 };
 

--- a/packages/vue/src/auth/mapAuthState.ts
+++ b/packages/vue/src/auth/mapAuthState.ts
@@ -153,8 +153,7 @@ export const useFronteggAuth = () => {
 };
 
 export const useLoadEntitlements = () => {
-  const loadEntitlements = inject(loadEntitlementsKey);
-  return loadEntitlements;
+  return inject(loadEntitlementsKey);
 };
 
 export const useFrontegg = () => {

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -8,6 +8,7 @@ export const fronteggLoadedKey = Symbol('fronteggLoade');
 export const authStateKey = Symbol('authState');
 export const unsubscribeFronteggStoreKey = Symbol('unsubscribeFronteggStore');
 export const fronteggAuthKey = Symbol('fronteggAuth');
+export const loadEntitlementsKey = Symbol('loadEntitlements');
 export const routerKey = Symbol('router');
 export const fronteggOptionsKey = Symbol('fronteggOptions');
 export const fronteggStoreKey = Symbol('fronteggStore');

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -34,7 +34,7 @@ declare module 'vue/types/vue' {
     getPermissionEntitlements: (_entitlements: User['entitlements'], key: string) => Entitlement;
 
     /**
-      @param options - including permission or feature key
+      @param entitledToOptions - including permission or feature key
       @returns if the user is entitled to the given permission or feature. Attaching the justification if not
       @throws when entitlement is not enabled via frontegg options
     */

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,5 +1,7 @@
 import { EnhancedStore } from '@reduxjs/toolkit';
 import { Unsubscribe } from 'redux';
+import { Entitlement, User } from '@frontegg/redux-store';
+import { EntitledToOptions, LoadEntitlementsCallback } from '@frontegg/types';
 import { FronteggPluginService } from './interfaces';
 
 declare module 'vue/types/vue' {
@@ -16,5 +18,32 @@ declare module 'vue/types/vue' {
     _data?: any;
     fronteggLoaded: boolean;
     loginWithRedirect: () => void;
+
+    /**
+      @param key feature
+      @returns if the user is entitled to the given feature. Attaching the justification if not
+      @throws when entitlement is not enabled via frontegg options
+    */
+    getFeatureEntitlements: (_entitlements: User['entitlements'], key: string) => Entitlement;
+
+    /**
+      @param key permission
+      @returns if the user is entitled to the given permission. Attaching the justification if not
+      @throws when entitlement is not enabled via frontegg options
+    */    
+    getPermissionEntitlements: (_entitlements: User['entitlements'], key: string) => Entitlement;
+
+    /**
+      @param options - including permission or feature key
+      @returns if the user is entitled to the given permission or feature. Attaching the justification if not
+      @throws when entitlement is not enabled via frontegg options
+    */
+    getEntitlements: (_entitlements: User['entitlements'], entitledToOptions: EntitledToOptions) => Entitlement;
+
+    /**
+     * Load entitlements
+     * @param callback called on request completed with true if succeeded, false if failed
+     */
+    loadEntitlements: (callback?: LoadEntitlementsCallback) => void;
   }
 }


### PR DESCRIPTION
[Notion](https://www.notion.so/frontegg/Entitlements-FE-SDK-1b5b83a102f3477fa5211b53cc0f1f1a?pvs=4#b039ddae7277448cb74507207f3b659f)
Allow consumers to fetch entitlements per key by exposing from the angular service, preferably by subscription.

Implementation for Vue2 and for Vue3.

Expose 4 APIs (for every vue version):
- `getFeatureEntitlements` / `useFeatureEntitlements`
- `getPermissionEntitlements` / `usePermissionEntitlements`
- `getEntitlements` / `useEntitlements`
- `loadEntitlements`