### PR TITLE
Update Frontegg AdminPortal to 6.134.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.126.0",
+    "@frontegg/js": "6.127.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.130.0",
+    "@frontegg/js": "6.131.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.128.0",
+    "@frontegg/js": "6.130.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.127.0",
+    "@frontegg/js": "6.128.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.131.0",
+    "@frontegg/js": "6.134.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,40 +1844,40 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.127.0":
-  version "6.127.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.127.0.tgz#b9c856fab7debdedfecfa9229a02f64980019995"
-  integrity sha512-ZwmjoM+2y12WxTQbTpQg+upaHJoAC7hXuILdC7pEgzZnzX13nYb0Lpc3J5RwxCWDuxeCgE/hfqAwf9s9HJdzMw==
+"@frontegg/js@6.128.0":
+  version "6.128.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.128.0.tgz#fd2221a446b2ac6f75295e0ce1001cd878ac6bc2"
+  integrity sha512-WvSDsvrK1GQp9wPWWS6lpAtEdnivAJLl5644MOxLmqpzP6kdYUtx1YLCElQytsEg6gtLnPBLT+iVwk7UZzzNRg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.127.0"
+    "@frontegg/types" "6.128.0"
 
-"@frontegg/redux-store@6.127.0":
-  version "6.127.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.127.0.tgz#56897e77b093d53ba43e31e0a3a3dffd7833e681"
-  integrity sha512-mGxWmlOma1QLDPosOzZPan2F5hSoa1sN/KN7YhhylT0rE8Xn/ARciY5oB42ImyznpVCCPngxqmfT8ftVxK+lPA==
+"@frontegg/redux-store@6.128.0":
+  version "6.128.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.128.0.tgz#fde6aac95d8baddeab37c4d015ff77ff6b8d8620"
+  integrity sha512-SUnxLcztPO4b2blAXT9eG6ouCMBf/ez76TyndX06YCA4o70dND+2jELVQ/j0zwQhmTQHLaMy98VpmvcR/scR1A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.1.9"
+    "@frontegg/rest-api" "3.1.11"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.1.9":
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.9.tgz#4fb72da050105c7bdff6a94028b72d80e4f86c84"
-  integrity sha512-hpOtlIxqlf262nzp9y8MG3VMtGQeLp9yZa1Hfz8hlOzAfeviYG55YptT4Dc/6poWmsfglnFcDuVKT7eGAvfyBg==
+"@frontegg/rest-api@3.1.11":
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.11.tgz#442476be3576a1e7bf455dffcf524a230cb2f1bd"
+  integrity sha512-JU7J69eOUnNRuIPG0emFpnyxdLln2MbKLCSL3evofkNMIYkKn7W2LbJ2c0rOTZTVwL8zC/xg7Qnssy4Kyd5kCw==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.127.0":
-  version "6.127.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.127.0.tgz#e87ce9bfca0aa9a8b394dfa23219336480c88262"
-  integrity sha512-4EwUwRRPYd2jcMOUym4SVsixaPODureSCG78hY94fMw43CknrWxj6QSiObSjM0SEgJS9qECCIzY1PWsw9fn/mQ==
+"@frontegg/types@6.128.0":
+  version "6.128.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.128.0.tgz#6ef01ee825a2860bc6da8732174f56a2f1e425bf"
+  integrity sha512-VV07u6suT/rIIiQS83KWlME97X8rDPq5bV7WtOm3jJSIXxACSEFNEcAQytynazvbrR3IWfYDv7O7MSOsh/e6xA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.127.0"
+    "@frontegg/redux-store" "6.128.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,40 +1844,40 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.128.0":
-  version "6.128.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.128.0.tgz#fd2221a446b2ac6f75295e0ce1001cd878ac6bc2"
-  integrity sha512-WvSDsvrK1GQp9wPWWS6lpAtEdnivAJLl5644MOxLmqpzP6kdYUtx1YLCElQytsEg6gtLnPBLT+iVwk7UZzzNRg==
+"@frontegg/js@6.130.0":
+  version "6.130.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.130.0.tgz#2ae22c1787ebd5c80ebeb96889157969798ec346"
+  integrity sha512-b9mr19Ys5KyU6ikWGfJGD5fYT/EK5f+jrASqndOlWAkNRmX2worGvd66+UjeMHodbWTn7plRDsxUBTlf/Qtn6w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.128.0"
+    "@frontegg/types" "6.130.0"
 
-"@frontegg/redux-store@6.128.0":
-  version "6.128.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.128.0.tgz#fde6aac95d8baddeab37c4d015ff77ff6b8d8620"
-  integrity sha512-SUnxLcztPO4b2blAXT9eG6ouCMBf/ez76TyndX06YCA4o70dND+2jELVQ/j0zwQhmTQHLaMy98VpmvcR/scR1A==
+"@frontegg/redux-store@6.130.0":
+  version "6.130.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.130.0.tgz#39532e4d879980705d7747a64c7250ea7868d35f"
+  integrity sha512-Sh8tfn0hybm2TGRS+GaoaGvbHNudXVEsM9ewUi3HnQbk8F1OqGRZvqxvO86GpVVPleiL/U83dqLd4X29OdDAZw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.1.11"
+    "@frontegg/rest-api" "3.1.12"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.1.11":
-  version "3.1.11"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.11.tgz#442476be3576a1e7bf455dffcf524a230cb2f1bd"
-  integrity sha512-JU7J69eOUnNRuIPG0emFpnyxdLln2MbKLCSL3evofkNMIYkKn7W2LbJ2c0rOTZTVwL8zC/xg7Qnssy4Kyd5kCw==
+"@frontegg/rest-api@3.1.12":
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.12.tgz#a543df3dd7636f0b136c12eb5dbbd3039808f05b"
+  integrity sha512-BTv9tA+W+d6hKNxYAtvEOyRBtZX0vmd3b7PCZ0DIEd+EbTN/ez948mS/xjhhazq+ul0GDfE5WpgR+dVaWk/eTA==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.128.0":
-  version "6.128.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.128.0.tgz#6ef01ee825a2860bc6da8732174f56a2f1e425bf"
-  integrity sha512-VV07u6suT/rIIiQS83KWlME97X8rDPq5bV7WtOm3jJSIXxACSEFNEcAQytynazvbrR3IWfYDv7O7MSOsh/e6xA==
+"@frontegg/types@6.130.0":
+  version "6.130.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.130.0.tgz#78c2fc4c62048fe39fdc781e78ca1d1b21bbaec5"
+  integrity sha512-UmxRRAIfcSbW/zYQr9CwFKXYn2cVjM320jEFgq2dimMadfj92PSx5joD9TXD7q8gMATXrXzkZhhPUkq+78Wn4Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.128.0"
+    "@frontegg/redux-store" "6.130.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.131.0":
-  version "6.131.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.131.0.tgz#462df1a21eae5cf52ea3e98094a8edf9547a3378"
-  integrity sha512-IY0c9jNtw7yQg9865zjg2rO4k8EyZIl7lGWEztDqEFtD6MvmCHbRQDm7tg71AsKGCMch37jCTuQ5Pl7FdlBNmg==
+"@frontegg/js@6.134.0":
+  version "6.134.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.134.0.tgz#875aa7eb0c30a00769f7f3e0f5eb07059976f33e"
+  integrity sha512-NBUu5rWh+zz/wJpvIkn3Dlk+fCiJi541ctLImS4H6FgYD9+1GBSGU9szX2+zEfDKBUHJvPQ148sVYDuzT0bjTQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.131.0"
+    "@frontegg/types" "6.134.0"
 
-"@frontegg/redux-store@6.131.0":
-  version "6.131.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.131.0.tgz#54a759a49563e951ff18c6cf20e32a8408dda46c"
-  integrity sha512-p2ngSHC33AwBuApr+ZE/WuCKv9G05HJ6KoEkdsRlggCokQqW6zvZKk0UiiAj4YSIPISzbsKrHW6HQO1MS5bzNg==
+"@frontegg/redux-store@6.134.0":
+  version "6.134.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.134.0.tgz#3731fd0151d791838d4f6c6d8786edb836270b41"
+  integrity sha512-kF7EbpdiW551AE4rLZKMU3IlBXUoeHOUaYhO1EbHh+l74ml2d9TTp0enOi1XUZIIwsOoZh9dwlU32Gw0j8KjNg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.1.12"
@@ -1871,13 +1871,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.131.0":
-  version "6.131.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.131.0.tgz#acdaa84717493808e2d637ea1e9a17149b65ba39"
-  integrity sha512-NKbEd85LkVzH5Pkt+dwo+NTDP+KQ6OohE0YGkHQi3j0vuObxN2VLY5WsbTOKDh4QLLCXNqfay13hNTvrP8+sCA==
+"@frontegg/types@6.134.0":
+  version "6.134.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.134.0.tgz#3ba9e45208427cf7137e49a6e69468fb59a2b4e6"
+  integrity sha512-ATUP8aV+5qwprIQQemKH8qXWWrNub1zw7MzZA64xNEMQwMNKRxBpGdjPtI6bEk+MAGXAEOfGgBhZEHmnJyyffQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.131.0"
+    "@frontegg/redux-store" "6.134.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,40 +1844,40 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.126.0":
-  version "6.126.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.126.0.tgz#3972ec1f8a1cbdace6505f6312186444944e1a32"
-  integrity sha512-mLzDn7dyPDwF098JZ9ET5Co4N6DlLoaBHk9fZ2PS82rIu0DCcuJxWoRrW01aZwXRA00LgJ20UnoeRe39ncbeLA==
+"@frontegg/js@6.127.0":
+  version "6.127.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.127.0.tgz#b9c856fab7debdedfecfa9229a02f64980019995"
+  integrity sha512-ZwmjoM+2y12WxTQbTpQg+upaHJoAC7hXuILdC7pEgzZnzX13nYb0Lpc3J5RwxCWDuxeCgE/hfqAwf9s9HJdzMw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.126.0"
+    "@frontegg/types" "6.127.0"
 
-"@frontegg/redux-store@6.126.0":
-  version "6.126.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.126.0.tgz#b3f35dadfddadf82227bbbe6840440b64c3fe17f"
-  integrity sha512-pOwhHayDQedzlBCWRCgPQnmdYXPlDqeZNDNClgdybqzrxhIfmJY2hUKTE8Eb08DmztpuBlsWYe5xaL2ZjX0sLQ==
+"@frontegg/redux-store@6.127.0":
+  version "6.127.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.127.0.tgz#56897e77b093d53ba43e31e0a3a3dffd7833e681"
+  integrity sha512-mGxWmlOma1QLDPosOzZPan2F5hSoa1sN/KN7YhhylT0rE8Xn/ARciY5oB42ImyznpVCCPngxqmfT8ftVxK+lPA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "3.1.7"
+    "@frontegg/rest-api" "3.1.9"
     "@reduxjs/toolkit" "1.8.5"
     fast-deep-equal "3.1.3"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.1.7":
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.7.tgz#04d71855d79e32a4fdceecf97950e961d6bb6e44"
-  integrity sha512-gHSn4thztsPTep421sUhkL6icY4CAT9nqf2QpLydiW6OTwVlAVDiFCtTPMpxx+Z2kpK54r8hpkdyDYUY1fSwWQ==
+"@frontegg/rest-api@3.1.9":
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.1.9.tgz#4fb72da050105c7bdff6a94028b72d80e4f86c84"
+  integrity sha512-hpOtlIxqlf262nzp9y8MG3VMtGQeLp9yZa1Hfz8hlOzAfeviYG55YptT4Dc/6poWmsfglnFcDuVKT7eGAvfyBg==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.126.0":
-  version "6.126.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.126.0.tgz#b08cf80aec3cbdec2d1e3175a2e10ab0a2979a64"
-  integrity sha512-gjWr2GCocN1+nO+Ka+Msd/mtH7RCMP/1T4QshWPNuJ1i1Jvex+HhHJ2rXaHjj4XUpTmo6fOTDYmxV8aMAyBqsA==
+"@frontegg/types@6.127.0":
+  version "6.127.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.127.0.tgz#e87ce9bfca0aa9a8b394dfa23219336480c88262"
+  integrity sha512-4EwUwRRPYd2jcMOUym4SVsixaPODureSCG78hY94fMw43CknrWxj6QSiObSjM0SEgJS9qECCIzY1PWsw9fn/mQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.126.0"
+    "@frontegg/redux-store" "6.127.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,18 +1844,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@frontegg/js@6.130.0":
-  version "6.130.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.130.0.tgz#2ae22c1787ebd5c80ebeb96889157969798ec346"
-  integrity sha512-b9mr19Ys5KyU6ikWGfJGD5fYT/EK5f+jrASqndOlWAkNRmX2worGvd66+UjeMHodbWTn7plRDsxUBTlf/Qtn6w==
+"@frontegg/js@6.131.0":
+  version "6.131.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.131.0.tgz#462df1a21eae5cf52ea3e98094a8edf9547a3378"
+  integrity sha512-IY0c9jNtw7yQg9865zjg2rO4k8EyZIl7lGWEztDqEFtD6MvmCHbRQDm7tg71AsKGCMch37jCTuQ5Pl7FdlBNmg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.130.0"
+    "@frontegg/types" "6.131.0"
 
-"@frontegg/redux-store@6.130.0":
-  version "6.130.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.130.0.tgz#39532e4d879980705d7747a64c7250ea7868d35f"
-  integrity sha512-Sh8tfn0hybm2TGRS+GaoaGvbHNudXVEsM9ewUi3HnQbk8F1OqGRZvqxvO86GpVVPleiL/U83dqLd4X29OdDAZw==
+"@frontegg/redux-store@6.131.0":
+  version "6.131.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.131.0.tgz#54a759a49563e951ff18c6cf20e32a8408dda46c"
+  integrity sha512-p2ngSHC33AwBuApr+ZE/WuCKv9G05HJ6KoEkdsRlggCokQqW6zvZKk0UiiAj4YSIPISzbsKrHW6HQO1MS5bzNg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.1.12"
@@ -1871,13 +1871,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.130.0":
-  version "6.130.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.130.0.tgz#78c2fc4c62048fe39fdc781e78ca1d1b21bbaec5"
-  integrity sha512-UmxRRAIfcSbW/zYQr9CwFKXYn2cVjM320jEFgq2dimMadfj92PSx5joD9TXD7q8gMATXrXzkZhhPUkq+78Wn4Q==
+"@frontegg/types@6.131.0":
+  version "6.131.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.131.0.tgz#acdaa84717493808e2d637ea1e9a17149b65ba39"
+  integrity sha512-NKbEd85LkVzH5Pkt+dwo+NTDP+KQ6OohE0YGkHQi3j0vuObxN2VLY5WsbTOKDh4QLLCXNqfay13hNTvrP8+sCA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.130.0"
+    "@frontegg/redux-store" "6.131.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- 

- FR-11857 - Added new support for hosted login to load user on load


- 

- FR-12855 - add sso recommendation
- FR-12942 - Fix next-js build with middleware file
- FR-12291 - msp change text

- FR-12818 - Handle permissions in the security center inner pages and modified the security center main page
- FR-12859 - Pipeline - fixed lerna version for the set alpha version step in the pipeline
