### PR TITLE
FR-12821 - Rule Based Entitlements - preparation for upgrading rest-api

### DIFF
--- a/packages/vue/src/auth/entitlements.ts
+++ b/packages/vue/src/auth/entitlements.ts
@@ -13,7 +13,7 @@ import { authStateKey } from '../constants';
 
 const getEntitlementsState = () => {
   const authState = inject(authStateKey) as AuthState;
-  return authState.user?.entitlements;
+  return authState.user?.entitlements as any;
 };
 
 /**


### PR DESCRIPTION
preparation for upgrading rest-api to prevent admin box frameworks testing failures
when upgrading rest-api to entitlements v2 the types are different.
Then when we want to upgrade admin box Vue tests fail because of mismatch of store types.
To support it this PR change types to any. We will fix it at the end.