### PR TITLE
Update Frontegg AdminPortal to 6.172.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.168.0",
+    "@frontegg/js": "6.169.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.167.0",
+    "@frontegg/js": "6.168.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.165.0",
+    "@frontegg/js": "6.166.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.166.0",
+    "@frontegg/js": "6.167.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.169.0",
+    "@frontegg/js": "6.170.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.171.0",
+    "@frontegg/js": "6.172.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "6.170.0",
+    "@frontegg/js": "6.171.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,18 +1849,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.165.0":
-  version "6.165.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.165.0.tgz#63ac356fe4dde0a269682085dd881b6f0af7b3f8"
-  integrity sha512-GYUCvaFqtPhSWTOs+xmg2/+LirN8IqwxxHDl5ASstWamq66dHQbIDRab6rbh/rQawqxo/mRe6nV3zRq3LaXrSg==
+"@frontegg/js@6.166.0":
+  version "6.166.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.166.0.tgz#be1b31ae25e707b89619370c9ee67ed08fb87d5a"
+  integrity sha512-ZNE4y5u3JWaZc6QnaPsnN44AQATwbnQk9OcoVB/SD4ZRUQ+kJWiLLjNfbfgjS9U2iy6WguBqS8+6SMXef4XKDw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.165.0"
+    "@frontegg/types" "6.166.0"
 
-"@frontegg/redux-store@6.165.0":
-  version "6.165.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.165.0.tgz#8d79cf51734286b0e004a47e14c1ed5fd3d90ac2"
-  integrity sha512-AIgXAXzKKub7UEfEG6Aqs1X0hF8jD13+8v5TpJ6Syjz6wP8l7FjPmzOWKdKrdN5a4WRfTWXt12qfde8hJpAAfQ==
+"@frontegg/redux-store@6.166.0":
+  version "6.166.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.166.0.tgz#e195e21d5d48c4e08e4d2d4a5a6b65cc1e01e945"
+  integrity sha512-28Jf0aGRgzUluOc4wkmiNasbogpj5LIHUhMeMn46PcN7FxdQcsmboxEFRyf7DXmS+VZ9/GTJJJtpW/Y/6SJn6w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1878,13 +1878,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.165.0":
-  version "6.165.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.165.0.tgz#01c7a03cbd628e6b02b5b32ec51df4bb814c42ed"
-  integrity sha512-aN9ZbTtf4GljU0lS+0jpsRL+sjN5lgfx53q1UdkFvSsdIgY51f39ANB/FWMHi/yEhA6t+Wws56GMVSxlZfNiHg==
+"@frontegg/types@6.166.0":
+  version "6.166.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.166.0.tgz#313ed9ff3b1f0250eab03dcaef8efdeac0783e3a"
+  integrity sha512-luYWWBDFDs6lrYq4L5XpAJ8GgLI7AvbDTcxEqSfVGa7lggH+a6nEYW07n3LvO+OU94qocJC30gEx6jeGNbydhQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.165.0"
+    "@frontegg/redux-store" "6.166.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,18 +1849,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.171.0":
-  version "6.171.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.171.0.tgz#5d68a925951b668565d0a09077f3e42ae3423877"
-  integrity sha512-7VYhY4qw3Dgkq8GzlTU39offTON3pLonoNtr4h7AkiIh/Lwqr/h0fSgwt1T2sZZn39s1PO752APtcGuEVTcC+g==
+"@frontegg/js@6.172.0":
+  version "6.172.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.172.0.tgz#d1aa9b550695996092fc5ea341d0bf2cfad982f5"
+  integrity sha512-ycfwXgwDZ42hxgxSXqv/PH2SppA3fY54yjODWIAxl6McczaFDdGkp6dILXgd2pnNJPvoVyVErkSaigAwD0e7Rg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.171.0"
+    "@frontegg/types" "6.172.0"
 
-"@frontegg/redux-store@6.171.0":
-  version "6.171.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.171.0.tgz#69b34a58ff3e1b5e25b9ee60e9ee7cf35677300c"
-  integrity sha512-lwkRb2L6WTNmjnUp9DzLe9KMMdKvKHW/9YIVjKdLRZke8PdF7zyBFWvolwnqqriXvIdRxa0pBAbXmRBNeTLB4A==
+"@frontegg/redux-store@6.172.0":
+  version "6.172.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.172.0.tgz#7a56835d3c4fd89d0f5db5bc946a2fa367524776"
+  integrity sha512-rER4zYd5fy8UaxY3zYX+nDcPh0OdIjirbAV+yR/3FU2BzSoMhYEFFYvZnwbUqgEF1nyZzRIMOYW/FaOfjs2OCw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1878,13 +1878,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.171.0":
-  version "6.171.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.171.0.tgz#52f0cfb2ba98d57c1725072a5484616e322c90c4"
-  integrity sha512-SNlsl0QU5weqk1iPoIYj2p6kuicbzytTpi6bhcZosKnwUEw8yPtzmMSGf1C3pQxRyEJHFE8qxspmWhL74PnoMg==
+"@frontegg/types@6.172.0":
+  version "6.172.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.172.0.tgz#023fdd78f5ba6a2359516b6a8f1bbce1a7cf6f7c"
+  integrity sha512-U1F7n0BpMYoUVG/G50gct/YIBY30OvisMARCdEBXOkvXCqyL39RCUsqNM0Xle8Dw9+KA/lxpko/lugdrc13EPQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.171.0"
+    "@frontegg/redux-store" "6.172.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,18 +1849,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.168.0":
-  version "6.168.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.168.0.tgz#b41d04a40424554e2b012c7f6f456865a579ce69"
-  integrity sha512-J+xqGzPn4yn3vFcsWIowUsoz4qSBc/5DMASRrkDgoehKUhaIAVuc+vMcZbtrKnfaMRKlCpMnaJ7SUDwcAAEVxQ==
+"@frontegg/js@6.169.0":
+  version "6.169.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.169.0.tgz#d14b738b7a501d9e8a366ae3485bcb0f36732f85"
+  integrity sha512-JZVlGcsQ0HQNV/ihJteC1QSiFUCa6Pw/RtR1q8twk6IcUA71Dvck1qpnmfBTuNHVfTzRfPZnc9QbzMUQGbS/5w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.168.0"
+    "@frontegg/types" "6.169.0"
 
-"@frontegg/redux-store@6.168.0":
-  version "6.168.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.168.0.tgz#46e2f0ea80908eb1e0ac149f4a1b3d5b87bc1c20"
-  integrity sha512-ZmacBo9r6UvqshmRJ5rPEoiPySNIkT9VSIret6tgPdixVNZsxeOy5uAkYMlevmTedS42YLWFqcgXoSIJZoRm+A==
+"@frontegg/redux-store@6.169.0":
+  version "6.169.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.169.0.tgz#6087b9d1542e558209dff40a5c2c047d96d28960"
+  integrity sha512-HdrBz0D2axRb4H8AVj4Pvg1wrJ9yXtG7Y60HXtKOFEF5SSiUGBtRR3rPefxiB+czW5PJPKALK/GgKNLOAdEfvg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1878,13 +1878,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.168.0":
-  version "6.168.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.168.0.tgz#d674d5edbe6911b811c9e54f4de9ac359ff6bd24"
-  integrity sha512-cC6wxOFxKYQTN31u+6tXwDpEgd677mWvRG8UXwXxN4+nm9hzPz9YIB13IJ5o9AIt9ZQ+4wkE4K0T4hHl6dTq/w==
+"@frontegg/types@6.169.0":
+  version "6.169.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.169.0.tgz#fb28e07d1f8ed4c213168964938cea284f9e4f16"
+  integrity sha512-WMFmm9+uO3axMZqHQzx49sbdxJp+zH7HpKWVU0fpDm2phYh07GC/PV0P9SiYWfnwWPxI18xCSwDeZLdjgPaiaQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.168.0"
+    "@frontegg/redux-store" "6.169.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,18 +1849,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.167.0":
-  version "6.167.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.167.0.tgz#9446af2afec7919bf145748c0c15555bc0dfca66"
-  integrity sha512-llMaHECtcBOYkTq3mmE1TPSYaxaYIANEfkFloFYwRS6W4ZHEqnw5GhLgpPVsxf/OuKvOa9YrVoUryjE3sNfehg==
+"@frontegg/js@6.168.0":
+  version "6.168.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.168.0.tgz#b41d04a40424554e2b012c7f6f456865a579ce69"
+  integrity sha512-J+xqGzPn4yn3vFcsWIowUsoz4qSBc/5DMASRrkDgoehKUhaIAVuc+vMcZbtrKnfaMRKlCpMnaJ7SUDwcAAEVxQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.167.0"
+    "@frontegg/types" "6.168.0"
 
-"@frontegg/redux-store@6.167.0":
-  version "6.167.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.167.0.tgz#8703485e746d00bb46e6e6a0cb3429aeade1b139"
-  integrity sha512-87+huw7iYG1637wN0i2RWGG+y1d/nC2K6bPgS5hVHkOwoxVgdbtluckn+SSLdy0TJoM5e2Wt4KOt/8iWiJoDKw==
+"@frontegg/redux-store@6.168.0":
+  version "6.168.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.168.0.tgz#46e2f0ea80908eb1e0ac149f4a1b3d5b87bc1c20"
+  integrity sha512-ZmacBo9r6UvqshmRJ5rPEoiPySNIkT9VSIret6tgPdixVNZsxeOy5uAkYMlevmTedS42YLWFqcgXoSIJZoRm+A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1878,13 +1878,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.167.0":
-  version "6.167.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.167.0.tgz#b68d8f8a418b312e090acce6028c55e7bebd6388"
-  integrity sha512-fe/AIzn1nj6+Ks5S1ycn3aCpfStgLcEaM+/KUAe86aOPCEZMkA+pwdxk3sjIUh8pfMLD+BGQYSk2iLrDwud7uQ==
+"@frontegg/types@6.168.0":
+  version "6.168.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.168.0.tgz#d674d5edbe6911b811c9e54f4de9ac359ff6bd24"
+  integrity sha512-cC6wxOFxKYQTN31u+6tXwDpEgd677mWvRG8UXwXxN4+nm9hzPz9YIB13IJ5o9AIt9ZQ+4wkE4K0T4hHl6dTq/w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.167.0"
+    "@frontegg/redux-store" "6.168.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,18 +1849,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.169.0":
-  version "6.169.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.169.0.tgz#d14b738b7a501d9e8a366ae3485bcb0f36732f85"
-  integrity sha512-JZVlGcsQ0HQNV/ihJteC1QSiFUCa6Pw/RtR1q8twk6IcUA71Dvck1qpnmfBTuNHVfTzRfPZnc9QbzMUQGbS/5w==
+"@frontegg/js@6.170.0":
+  version "6.170.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.170.0.tgz#aee4ad737b31427e35282ecc171e3d5b75e430aa"
+  integrity sha512-GW6vVr337G6xiOGiL080EzwB/Py3C6jIglrY+Fb66b713ZOrQoAHX9g5culiukGS6DWPZ8MNEC6vpCRcxfXmmQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.169.0"
+    "@frontegg/types" "6.170.0"
 
-"@frontegg/redux-store@6.169.0":
-  version "6.169.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.169.0.tgz#6087b9d1542e558209dff40a5c2c047d96d28960"
-  integrity sha512-HdrBz0D2axRb4H8AVj4Pvg1wrJ9yXtG7Y60HXtKOFEF5SSiUGBtRR3rPefxiB+czW5PJPKALK/GgKNLOAdEfvg==
+"@frontegg/redux-store@6.170.0":
+  version "6.170.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.170.0.tgz#a3ebb5231b1380112ea97f81e76a6e6043f7fbc8"
+  integrity sha512-xF3Ih+o7Yna4b1xx5kq0O86Zd5/wNKOJAKUKWeMht/UR7WsbT+kwncrCVC+/FGGI18aNxV3goSlld+oKhjF/yQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1878,13 +1878,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.169.0":
-  version "6.169.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.169.0.tgz#fb28e07d1f8ed4c213168964938cea284f9e4f16"
-  integrity sha512-WMFmm9+uO3axMZqHQzx49sbdxJp+zH7HpKWVU0fpDm2phYh07GC/PV0P9SiYWfnwWPxI18xCSwDeZLdjgPaiaQ==
+"@frontegg/types@6.170.0":
+  version "6.170.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.170.0.tgz#d40181278e49ba10a63ed153908883dc84c54769"
+  integrity sha512-CMMg2uWBzDTSOtIVqaZ+i2njJ7iixWqQMt7qVDj9TATArJtmnSBUkIuRuiYhdhgj3HGNIOuTGb8Q6fjtjUHxhg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.169.0"
+    "@frontegg/redux-store" "6.170.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,18 +1849,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.166.0":
-  version "6.166.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.166.0.tgz#be1b31ae25e707b89619370c9ee67ed08fb87d5a"
-  integrity sha512-ZNE4y5u3JWaZc6QnaPsnN44AQATwbnQk9OcoVB/SD4ZRUQ+kJWiLLjNfbfgjS9U2iy6WguBqS8+6SMXef4XKDw==
+"@frontegg/js@6.167.0":
+  version "6.167.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.167.0.tgz#9446af2afec7919bf145748c0c15555bc0dfca66"
+  integrity sha512-llMaHECtcBOYkTq3mmE1TPSYaxaYIANEfkFloFYwRS6W4ZHEqnw5GhLgpPVsxf/OuKvOa9YrVoUryjE3sNfehg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.166.0"
+    "@frontegg/types" "6.167.0"
 
-"@frontegg/redux-store@6.166.0":
-  version "6.166.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.166.0.tgz#e195e21d5d48c4e08e4d2d4a5a6b65cc1e01e945"
-  integrity sha512-28Jf0aGRgzUluOc4wkmiNasbogpj5LIHUhMeMn46PcN7FxdQcsmboxEFRyf7DXmS+VZ9/GTJJJtpW/Y/6SJn6w==
+"@frontegg/redux-store@6.167.0":
+  version "6.167.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.167.0.tgz#8703485e746d00bb46e6e6a0cb3429aeade1b139"
+  integrity sha512-87+huw7iYG1637wN0i2RWGG+y1d/nC2K6bPgS5hVHkOwoxVgdbtluckn+SSLdy0TJoM5e2Wt4KOt/8iWiJoDKw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1878,13 +1878,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.166.0":
-  version "6.166.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.166.0.tgz#313ed9ff3b1f0250eab03dcaef8efdeac0783e3a"
-  integrity sha512-luYWWBDFDs6lrYq4L5XpAJ8GgLI7AvbDTcxEqSfVGa7lggH+a6nEYW07n3LvO+OU94qocJC30gEx6jeGNbydhQ==
+"@frontegg/types@6.167.0":
+  version "6.167.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.167.0.tgz#b68d8f8a418b312e090acce6028c55e7bebd6388"
+  integrity sha512-fe/AIzn1nj6+Ks5S1ycn3aCpfStgLcEaM+/KUAe86aOPCEZMkA+pwdxk3sjIUh8pfMLD+BGQYSk2iLrDwud7uQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.166.0"
+    "@frontegg/redux-store" "6.167.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,18 +1849,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.0.1.tgz#038a5b86166bd00cfd3afa942de361434c34ea04"
   integrity sha512-Ny9M9wLcA6/p9OD09plK3ETy5zyTWpgFoIorAYYYxk4J3S6ardsUOai2MlBmXqbG9J1uxD66rdFF5qr4bwqgyw==
 
-"@frontegg/js@6.170.0":
-  version "6.170.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.170.0.tgz#aee4ad737b31427e35282ecc171e3d5b75e430aa"
-  integrity sha512-GW6vVr337G6xiOGiL080EzwB/Py3C6jIglrY+Fb66b713ZOrQoAHX9g5culiukGS6DWPZ8MNEC6vpCRcxfXmmQ==
+"@frontegg/js@6.171.0":
+  version "6.171.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.171.0.tgz#5d68a925951b668565d0a09077f3e42ae3423877"
+  integrity sha512-7VYhY4qw3Dgkq8GzlTU39offTON3pLonoNtr4h7AkiIh/Lwqr/h0fSgwt1T2sZZn39s1PO752APtcGuEVTcC+g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.170.0"
+    "@frontegg/types" "6.171.0"
 
-"@frontegg/redux-store@6.170.0":
-  version "6.170.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.170.0.tgz#a3ebb5231b1380112ea97f81e76a6e6043f7fbc8"
-  integrity sha512-xF3Ih+o7Yna4b1xx5kq0O86Zd5/wNKOJAKUKWeMht/UR7WsbT+kwncrCVC+/FGGI18aNxV3goSlld+oKhjF/yQ==
+"@frontegg/redux-store@6.171.0":
+  version "6.171.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.171.0.tgz#69b34a58ff3e1b5e25b9ee60e9ee7cf35677300c"
+  integrity sha512-lwkRb2L6WTNmjnUp9DzLe9KMMdKvKHW/9YIVjKdLRZke8PdF7zyBFWvolwnqqriXvIdRxa0pBAbXmRBNeTLB4A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
@@ -1878,13 +1878,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.0.1"
 
-"@frontegg/types@6.170.0":
-  version "6.170.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.170.0.tgz#d40181278e49ba10a63ed153908883dc84c54769"
-  integrity sha512-CMMg2uWBzDTSOtIVqaZ+i2njJ7iixWqQMt7qVDj9TATArJtmnSBUkIuRuiYhdhgj3HGNIOuTGb8Q6fjtjUHxhg==
+"@frontegg/types@6.171.0":
+  version "6.171.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.171.0.tgz#52f0cfb2ba98d57c1725072a5484616e322c90c4"
+  integrity sha512-SNlsl0QU5weqk1iPoIYj2p6kuicbzytTpi6bhcZosKnwUEw8yPtzmMSGf1C3pQxRyEJHFE8qxspmWhL74PnoMg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.170.0"
+    "@frontegg/redux-store" "6.171.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-14855 - Add support for social login consent, by default it&#39;s false.


- FR-14813 - Add support for open app page with basename


- FR-14813 - Fix texts in open app

- FR-14813 - Support mobile deep link redirect page


- FR-14807 - Fixed step up double call to generate step up session


- FR-14753 - Fixed step up key removing when user doesn&#39;t finish step up flow


- FR-14228 - Added Step Up feature to allow a second layer of authentication for sensitive actions
