### PR TITLE
Update Frontegg AdminPortal to 7.26.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.18.0",
+    "@frontegg/js": "7.19.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.25.0",
+    "@frontegg/js": "7.26.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.19.0",
+    "@frontegg/js": "7.25.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.16.0",
+    "@frontegg/js": "7.17.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.17.0",
+    "@frontegg/js": "7.18.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,43 +1842,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.18.0.tgz#550fb0c9e1d6a6bd44f24baad81fc2fd4f6e938f"
-  integrity sha512-jWErskO3Ab12e0Wdk9GvQ3/dFSeJGtG5jDfwjFe4MIw5PG3MRzvYEytmsMk9PUgfsAcaV4HUMdpttPGVW9UFXQ==
+"@frontegg/js@7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.19.0.tgz#273fcdd31a1b7e875b9bfa4fdadb4e530d28db89"
+  integrity sha512-8rx+RAMalfH4XWe0WUINLPkn8iv2Vk9mgEP+tArillgOaxeZNcBZRul9TPn7NSo6cupUE+b0F9+PBssZONly1Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.18.0"
+    "@frontegg/types" "7.19.0"
 
-"@frontegg/redux-store@7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.18.0.tgz#87cbdef1259ecf5108062a81985f3cd929c76bac"
-  integrity sha512-u6P8EDsB4aXb6adhSUM3sPUvnFJtoxDXzIWXN2g+zAu7VS2GXnWAiP5/wqhKga1m3CsSseTq2Co4+pEn48MW7Q==
+"@frontegg/redux-store@7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.19.0.tgz#9b08bec70c54271147ba49f432e226c46ffa0c68"
+  integrity sha512-PEaRCrWd9cHbIEViZTwO0wSnTT9zAQ8SdFM87psiCy/MvnvsWfzBvX71gOTgH8M2H/0PDkppFQi6QpbNWlCd+g==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "3.2.4"
+    "@frontegg/rest-api" "3.2.5"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.2.4.tgz#4e50f85a3eebd86d2c8a0724c2bd5006cb54adf9"
-  integrity sha512-hs8YLfBiyiljF82U3YC9CI08Xl9+SPa/o/9VkAgJ71eErsNx0pU6psfRkxokIa6C2nsz/p4h8xdqZheRYpdrbA==
+"@frontegg/rest-api@3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.2.5.tgz#29de0198b8d0538195f77ccacc635ab670e6c595"
+  integrity sha512-H4Yt4a/wzfUoD87zdzLSiG8NVarm4TaYcQ+ICWGVm4o0Ca5XnrdQh4SIjcz3w6zabY0FgFrp0kRYnR9mdpzhKA==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.18.0.tgz#b50657dde0edf24364794977269f982c72d9bb20"
-  integrity sha512-qjzTp27H1YIEncS3pzQ85TyeXi+x2z8qn4nTlCq5QIsmxjgzygyNSxrLSSJkXg6Lmv5R+1SGDEiApl9/m3sLNg==
+"@frontegg/types@7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.19.0.tgz#04a474865dcf34646e8352e3260b4bf14057bd67"
+  integrity sha512-kFTJBuQi7/XLsqwltKL7RSGSbb2FrlYUVtrnzA4m2Ngr2LteCBGsR/PZxmC4IkGdr8k/v3oU5qq6h7U38TX2dg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.18.0"
+    "@frontegg/redux-store" "7.19.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,18 +1842,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.19.0.tgz#273fcdd31a1b7e875b9bfa4fdadb4e530d28db89"
-  integrity sha512-8rx+RAMalfH4XWe0WUINLPkn8iv2Vk9mgEP+tArillgOaxeZNcBZRul9TPn7NSo6cupUE+b0F9+PBssZONly1Q==
+"@frontegg/js@7.25.0":
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.25.0.tgz#4e9ca0bbaaad3bfb84a7b16613aec9ef101b539e"
+  integrity sha512-f4G9GZ6UiFshcxgt2/SiX4aPUKNv/Q901YDQd5uythnDDtzlavck2860nOYoOFpic8NdAtVLKHCwe76zP8FUCQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.19.0"
+    "@frontegg/types" "7.25.0"
 
-"@frontegg/redux-store@7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.19.0.tgz#9b08bec70c54271147ba49f432e226c46ffa0c68"
-  integrity sha512-PEaRCrWd9cHbIEViZTwO0wSnTT9zAQ8SdFM87psiCy/MvnvsWfzBvX71gOTgH8M2H/0PDkppFQi6QpbNWlCd+g==
+"@frontegg/redux-store@7.25.0":
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.25.0.tgz#aba200e756eaccac58798fe104727a90ff3322b7"
+  integrity sha512-lvZPPK7iaR4KAtTNPC0kpngzMlZdlVkuxXl8A4fbfIXaKi56ufsCbraSqr1HvSbbnTLTASO8gacXq5ep0hjDDA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
@@ -1872,13 +1872,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.19.0.tgz#04a474865dcf34646e8352e3260b4bf14057bd67"
-  integrity sha512-kFTJBuQi7/XLsqwltKL7RSGSbb2FrlYUVtrnzA4m2Ngr2LteCBGsR/PZxmC4IkGdr8k/v3oU5qq6h7U38TX2dg==
+"@frontegg/types@7.25.0":
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.25.0.tgz#505c64ffe704858eaaf6cccf77bba53b6b63f846"
+  integrity sha512-Z51+sUQprmDNmm2s7KU88DXPWTZqLXqZu/i78CpTS4mdGOgS3JGa6/cFq6rGVKdnXFjvJX+M9yANrZSQolkqtw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.19.0"
+    "@frontegg/redux-store" "7.25.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,18 +1842,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.25.0.tgz#4e9ca0bbaaad3bfb84a7b16613aec9ef101b539e"
-  integrity sha512-f4G9GZ6UiFshcxgt2/SiX4aPUKNv/Q901YDQd5uythnDDtzlavck2860nOYoOFpic8NdAtVLKHCwe76zP8FUCQ==
+"@frontegg/js@7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.26.0.tgz#45000b06cc2a2e9a901a0ea27d8eb231eab2ff0b"
+  integrity sha512-wl2+D65idAdiyzZeUaQeCBoXPZC3m8S3PVXDDezDUjvAqWF0B/dJLknCoE1xlL3kU5nuRar7FOXQK6XEmvwY5w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.25.0"
+    "@frontegg/types" "7.26.0"
 
-"@frontegg/redux-store@7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.25.0.tgz#aba200e756eaccac58798fe104727a90ff3322b7"
-  integrity sha512-lvZPPK7iaR4KAtTNPC0kpngzMlZdlVkuxXl8A4fbfIXaKi56ufsCbraSqr1HvSbbnTLTASO8gacXq5ep0hjDDA==
+"@frontegg/redux-store@7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.26.0.tgz#99bb763484a7d4f6377cd9881bef75ecf8dbe28e"
+  integrity sha512-MfuLirJ8TnuMCorvkyvQ0KF9Fl8EwMVxsAinXO6VzaU64vIiu0JBqQK9mFdXNX71ac8jOXh8RjdoDO9XDH3kNw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
@@ -1872,13 +1872,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.25.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.25.0.tgz#505c64ffe704858eaaf6cccf77bba53b6b63f846"
-  integrity sha512-Z51+sUQprmDNmm2s7KU88DXPWTZqLXqZu/i78CpTS4mdGOgS3JGa6/cFq6rGVKdnXFjvJX+M9yANrZSQolkqtw==
+"@frontegg/types@7.26.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.26.0.tgz#d1ca8ea33f70f5fab2ed77a83bb848df06ed0f02"
+  integrity sha512-IWPtKC0X3yKjD5AS9qqUAlIvh7RO2cV2K0N66M9iq8sXAbyF9YHCAJ2rpg1FD3ZoZTIzsnRBuvfUfDPcD5vRWw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.25.0"
+    "@frontegg/redux-store" "7.26.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,43 +1842,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.17.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.17.0.tgz#7a200b3f11670078474b54a466c1b69bf2f68b1b"
-  integrity sha512-etKsTGq0pmINcP+AfrsLg0zgb/LNLS58DBcI+EFhLGh3Z6UcL/6Js1lBsf1ySYWFaNJ/mBidPvykSSP9yZv8pw==
+"@frontegg/js@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.18.0.tgz#550fb0c9e1d6a6bd44f24baad81fc2fd4f6e938f"
+  integrity sha512-jWErskO3Ab12e0Wdk9GvQ3/dFSeJGtG5jDfwjFe4MIw5PG3MRzvYEytmsMk9PUgfsAcaV4HUMdpttPGVW9UFXQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.17.0"
+    "@frontegg/types" "7.18.0"
 
-"@frontegg/redux-store@7.17.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.17.0.tgz#61cfbbee4f7704b9f59b17d8a87d91b24c4b199a"
-  integrity sha512-F+shV+6GEfX+cwAdyK9yteyx9UNXDlbGuCBMtaLTys0hLk4lku3im7bMYZF4NwC6NgvwU74ZpT03g+0beVpOnA==
+"@frontegg/redux-store@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.18.0.tgz#87cbdef1259ecf5108062a81985f3cd929c76bac"
+  integrity sha512-u6P8EDsB4aXb6adhSUM3sPUvnFJtoxDXzIWXN2g+zAu7VS2GXnWAiP5/wqhKga1m3CsSseTq2Co4+pEn48MW7Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "3.2.2"
+    "@frontegg/rest-api" "3.2.4"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@3.2.2":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.2.2.tgz#db7f021ecd4be2516111154e32bda89d7a1329a8"
-  integrity sha512-WpWd9kFVQJtTdsrTJyCGtezVHBjepUqvNznlSB/UtRB6FAsnyfaCIsg/1sSUn/WxF1iIk7k2tM/JjcFEcvfTYQ==
+"@frontegg/rest-api@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.2.4.tgz#4e50f85a3eebd86d2c8a0724c2bd5006cb54adf9"
+  integrity sha512-hs8YLfBiyiljF82U3YC9CI08Xl9+SPa/o/9VkAgJ71eErsNx0pU6psfRkxokIa6C2nsz/p4h8xdqZheRYpdrbA==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.17.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.17.0.tgz#5beb8066a4f27e1a4b679da1e675c7f6e7130a98"
-  integrity sha512-KWu39JJ269WTSS+tDBm6JCqUL6gXvr+ZLmGBQ6YfDEXEzJuP95m1r3t+HcHg8jH/ieKof1IfYqnc6ZVXsTqu4A==
+"@frontegg/types@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.18.0.tgz#b50657dde0edf24364794977269f982c72d9bb20"
+  integrity sha512-qjzTp27H1YIEncS3pzQ85TyeXi+x2z8qn4nTlCq5QIsmxjgzygyNSxrLSSJkXg6Lmv5R+1SGDEiApl9/m3sLNg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.17.0"
+    "@frontegg/redux-store" "7.18.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,18 +1842,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.16.0.tgz#44077dd4cdb7b386c1c2ac473492c9c97682afbb"
-  integrity sha512-yw9nzOgQ6vsb2OJfjXlRqzRk6vjpvQcv2MwyRiZ9lhfhD4dKn/0f0zXwYa2/mYyGaYLwj5TvZZYsJVxtRtDtKw==
+"@frontegg/js@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.17.0.tgz#7a200b3f11670078474b54a466c1b69bf2f68b1b"
+  integrity sha512-etKsTGq0pmINcP+AfrsLg0zgb/LNLS58DBcI+EFhLGh3Z6UcL/6Js1lBsf1ySYWFaNJ/mBidPvykSSP9yZv8pw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.16.0"
+    "@frontegg/types" "7.17.0"
 
-"@frontegg/redux-store@7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.16.0.tgz#ae5c1e765b774a8a67bf0b7c02de4477f4e6b984"
-  integrity sha512-xE48ZT3cJAv3G7NoeOywv63eMZRHK4vQsEe6QrPOXsZOey12neg0U8eZ+0mIEoek/n/HRH263sPNHNRx+l58AA==
+"@frontegg/redux-store@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.17.0.tgz#61cfbbee4f7704b9f59b17d8a87d91b24c4b199a"
+  integrity sha512-F+shV+6GEfX+cwAdyK9yteyx9UNXDlbGuCBMtaLTys0hLk4lku3im7bMYZF4NwC6NgvwU74ZpT03g+0beVpOnA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
@@ -1872,13 +1872,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.16.0.tgz#9dd36322d2cfb7402bbcf99f88831319232baf5f"
-  integrity sha512-8NjotvvkMX/cSWkMGmDw2rPkuwqGT9DNF8dVDZbJWNt9AZV9Ob0Tm8qkOEFX4BlB2b1ckeK+1xCeGp+vLrvilg==
+"@frontegg/types@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.17.0.tgz#5beb8066a4f27e1a4b679da1e675c7f6e7130a98"
+  integrity sha512-KWu39JJ269WTSS+tDBm6JCqUL6gXvr+ZLmGBQ6YfDEXEzJuP95m1r3t+HcHg8jH/ieKof1IfYqnc6ZVXsTqu4A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.16.0"
+    "@frontegg/redux-store" "7.17.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-18529 - Fixed empty roles field bug when appName is provided


- FR-18353 - Fixed tooltips mount component
- FR-18476 - Added url for beforeRequestInterceptor function
- FR-18476 - Added request interceptor
- FR-18472 - Fixed Google one tap login stuck after unmounting login
- FR-18436 - Fixed activate account with empty redirect bug
