### PR TITLE
Update Frontegg AdminPortal to 7.54.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.53.0",
+    "@frontegg/js": "7.54.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,43 +1835,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.53.0":
-  version "7.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.53.0.tgz#e3cf4484c07d292125ad41a0a9e2bc3d38fc77ef"
-  integrity sha512-Gjb0p2oB2vai2iNKQrAd/2JCR97g77W59b7kBK55nI+vvPiL9N4vz2UgA4hX2jmmGvX0G5DAVcZp9M69S4wztg==
+"@frontegg/js@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.54.0.tgz#1eef4b5ca6e8c3edd2e4e371f602a74692322da8"
+  integrity sha512-LFTRquSC5BqX32UlWtVOrsuLN2ybilgUbffQa6GMQE4RCb2ZHqB3+qIwrdrt10Ntsw2Nb19RRiFDMP1S3u8bpg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.53.0"
+    "@frontegg/types" "7.54.0"
 
-"@frontegg/redux-store@7.53.0":
-  version "7.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.53.0.tgz#b98a2605a5a13cfe0fc5d46d2b8cab4c73627337"
-  integrity sha512-4DV+bSp8fcFDFzTJ/W/gVrvY76poqBFoK23/mjUYTeuJldf3akxXHLGnDXgp1xUvlAwR8L7xVI/8DKdioJl1tA==
+"@frontegg/redux-store@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.54.0.tgz#61fe2904b83b3bdf945abef8ae0fbe9ff70a7ecc"
+  integrity sha512-3F0QzER5K4s/MmQKWrx0zMTwUA1AC4jhv24y5aOG448DHCRiELFwP1rvZLxAm9elTrO3YNc9M0NmKawz2RR0Ng==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.53.0"
+    "@frontegg/rest-api" "7.54.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.53.0":
-  version "7.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.53.0.tgz#2bc30d4ca6a3cb037448657e90f9a49b514e7720"
-  integrity sha512-NHiwQqmx5YksK0S1Wjy6+t5r1E0LEfi1/aXJRVlCfEDdgeOjhtOvuOyPKfMKXiP5e6W8+ENknc3leroSpopRzA==
+"@frontegg/rest-api@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.54.0.tgz#ed427c7933b1277b7a9cdb6e9247ce96996cde95"
+  integrity sha512-bmo6qDq/JNj/9BFS/KWNYViXotKHnXdSdZXS5puzqI7/c6GET0vIzP3J/d1Ev5Rk1XHiIqrCq0gPwP4n+SACIw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.53.0":
-  version "7.53.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.53.0.tgz#1c11b37f79b0e4da36f910f06ffcedf4f1cf2f80"
-  integrity sha512-Kyod1Am477uMy4xFjEklOj7gxyYvFuqAfI3MEZO67AbtURJ7eg3YN7KrCXfZscAfOSKrH7U5YNU/IK3AeA4rng==
+"@frontegg/types@7.54.0":
+  version "7.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.54.0.tgz#5da101c200a4589a6c272abb7b749c6704854cde"
+  integrity sha512-nnD/wCD0l1FmRm4t4WCjVYTlmoYRREslzHRUiTNjdSohBBalMJ8iunLWgUHlcUeltyBuDVg3xLtwgUSAApn+KQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.53.0"
+    "@frontegg/redux-store" "7.54.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-19547 - Added prestep support for auth flows
- FR-19048 - Changed sign-up with 6 digit code flow
- FR-19626 - Added support for social login eventually style
- FR-9045 - Fixed login form placeholder color
