### PR TITLE
Update Frontegg AdminPortal to 7.105.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.104.0",
+    "@frontegg/js": "7.105.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,43 +1835,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.104.0.tgz#fcdd6a5d3cd4af24604ee57e5f618935d92191ba"
-  integrity sha512-OeR6lQGSQ3MiUCOYhyqnbZ3aKyQL2U0gKr6CQOP7iecHioAHWCYL04ew/0HGiHOCga9uEIYEhS81n7OOQaW04w==
+"@frontegg/js@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.105.0.tgz#0bc161ae0bd114dfea329060652960a1a9484ed2"
+  integrity sha512-qeY9PHQyUcpnEqcJvRkA0bnURZITSyzIEt4s8wrAzt11D0BlcwupAW1LNUxB7FzZYF50U9i+VDSTE7bnU1HbEQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.104.0"
+    "@frontegg/types" "7.105.0"
 
-"@frontegg/redux-store@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.104.0.tgz#765d9b22ec3ef0905b6502d754bac1d5f7903e78"
-  integrity sha512-QYHo7b8hQ5sOlPGmMCM9WBfN8kG/i5kbGGeXswSOqPCuj5PM9Q3Sv5NtOHHL6VeFwbCyq78vBTVRRG0tYeEP5Q==
+"@frontegg/redux-store@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.105.0.tgz#270da43dd6a57626371f23189b61f542ed569efe"
+  integrity sha512-+0YZjLYFItW/YEdYbIPKQQF7qCOIIRIwep6XAXvQMper0wwkv4PHOTcEpJrVy7lFC9WcJNYGqf6eBoKLfj6bFg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.104.0"
+    "@frontegg/rest-api" "7.105.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.104.0.tgz#38cd79d885ca97290750a8d239d89aa55ec771a2"
-  integrity sha512-2xjBgHxOrFsJ9+4XYlHGFxOiwUExCy6ATUcBq9jJnED8gRkgTIETjSRVuMdG7LmrTwODME+t4aMyEul0WWhYxw==
+"@frontegg/rest-api@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.105.0.tgz#f6e5bfd2555272ffcd9b6603fa2a7f7b6baa1528"
+  integrity sha512-LQJduI+7V5jRSBi9C5sbyuSjp8KcBU4loMaTO3PuXSBEm9bjEAju4EO/oqrTOEhP1gHKORGfRRkhMM9LkSW4WQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.104.0":
-  version "7.104.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.104.0.tgz#fe6ebc8b66f1259ec4057fcaa5388d76d14f3f6e"
-  integrity sha512-GPxfdP3s+4fcQc5UYdikV+wQGpvRBJK3g83GFZwTfhfSWWCMISQrr4wBtXDF1Yv19G6SRU6MZlnOI+cj84jafg==
+"@frontegg/types@7.105.0":
+  version "7.105.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.105.0.tgz#96bf991f7efa06621583c1f19dbc071d0d6f7f29"
+  integrity sha512-3SXrUw2ifmJ2c3qNQbiTe0GWIxNF1Dg8BMbs8RisfEkMennNq5o8EU4c3ISbizRrfIZZIDeek30Jqb949DsF3A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.104.0"
+    "@frontegg/redux-store" "7.105.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-23435 - Added country restriction features to Security Center
- FR-23515 - Fixed wrong audit log tooltips
- FR-23524 - Added guidesCdnUrl to SSOPage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only update, but it upgrades the core `@frontegg/js` bundle (and transitive `@frontegg/*` packages), which could change AdminPortal/auth behavior at runtime.
> 
> **Overview**
> Updates the Vue package to use `@frontegg/js` `7.105.0` (from `7.104.0`).
> 
> Refreshes `yarn.lock` to pull the matching `7.105.0` versions of `@frontegg/types`, `@frontegg/redux-store`, and `@frontegg/rest-api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ef6c5e0e0819bab4793ff66f705def64f3db1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->