### PR TITLE
Update Frontegg AdminPortal to 7.106.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.105.0",
+    "@frontegg/js": "7.106.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,43 +1835,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.105.0.tgz#0bc161ae0bd114dfea329060652960a1a9484ed2"
-  integrity sha512-qeY9PHQyUcpnEqcJvRkA0bnURZITSyzIEt4s8wrAzt11D0BlcwupAW1LNUxB7FzZYF50U9i+VDSTE7bnU1HbEQ==
+"@frontegg/js@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.106.0.tgz#83dcb57ce1463c8930b55ef03c9814b1996618e6"
+  integrity sha512-68TUOiG6xl5N9IXGmhDOeV0jKWwN9tQqPc98nI3OxHbZyPPOYxWINOTpj24W4wb81nU4pCZ8ffuGneL76QKbkQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.105.0"
+    "@frontegg/types" "7.106.0"
 
-"@frontegg/redux-store@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.105.0.tgz#270da43dd6a57626371f23189b61f542ed569efe"
-  integrity sha512-+0YZjLYFItW/YEdYbIPKQQF7qCOIIRIwep6XAXvQMper0wwkv4PHOTcEpJrVy7lFC9WcJNYGqf6eBoKLfj6bFg==
+"@frontegg/redux-store@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.106.0.tgz#4cf6e36ac939bd88b1e2147f19b523b83011b89a"
+  integrity sha512-H4QXJEPkQd2t505C92FanfjAW12kPIZsaal+tgReJQqEixQUL8wbXZoe9pp48s9qUgaKoUd1F+dQ0AkdFulO8A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.105.0"
+    "@frontegg/rest-api" "7.106.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.105.0.tgz#f6e5bfd2555272ffcd9b6603fa2a7f7b6baa1528"
-  integrity sha512-LQJduI+7V5jRSBi9C5sbyuSjp8KcBU4loMaTO3PuXSBEm9bjEAju4EO/oqrTOEhP1gHKORGfRRkhMM9LkSW4WQ==
+"@frontegg/rest-api@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.106.0.tgz#779d18b9e5d59e4301197bf165219eb2c7d6290e"
+  integrity sha512-a28vI8oFIFJPeFqrLw+Q9aJxCyoWaB1eOGzV5j7F/M8Q+zko4ac3AMXCTf1MfWyrMKk71L5DLoSX8f5z6B0xhA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.105.0":
-  version "7.105.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.105.0.tgz#96bf991f7efa06621583c1f19dbc071d0d6f7f29"
-  integrity sha512-3SXrUw2ifmJ2c3qNQbiTe0GWIxNF1Dg8BMbs8RisfEkMennNq5o8EU4c3ISbizRrfIZZIDeek30Jqb949DsF3A==
+"@frontegg/types@7.106.0":
+  version "7.106.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.106.0.tgz#1c59f8b36fb80b33eab84fa6ad076815d4a499ed"
+  integrity sha512-emVdoZKQZ4Am3VYeF93BYC+qkzcxbWWBdtk3LKxwzBfzk6Fo7aLHNV3ThWZf2igNU+z5aK0fMyoM4Kiijb6eYw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.105.0"
+    "@frontegg/redux-store" "7.106.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24187 - Fixed CPU issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency update, but it may introduce behavior/performance changes from the upstream `@frontegg/*` packages at runtime.
> 
> **Overview**
> Updates the `@frontegg/vue` package to depend on `@frontegg/js` `7.106.0` (from `7.105.0`).
> 
> Regenerates `yarn.lock` to pull in the corresponding `7.106.0` versions of related transitive Frontegg packages (`@frontegg/types`, `@frontegg/redux-store`, `@frontegg/rest-api`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2af4f5010ebbe85aba9301ad776b3b5844a5af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->