### PR TITLE
Update Frontegg AdminPortal to 7.121.0

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.119.0",
+    "@frontegg/js": "7.120.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -22,7 +22,7 @@
     "build:unpkg": "cross-env NODE_ENV=production rollup --config rollup.config.js --format iife"
   },
   "dependencies": {
-    "@frontegg/js": "7.120.0",
+    "@frontegg/js": "7.121.0",
     "get-value": "^3.0.1",
     "set-value": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,43 +1835,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.120.0.tgz#724392aeb510d3701ebaa6e17b882b2c681f35e0"
-  integrity sha512-He9hxIBNelS6V9NhuGYS84rH2Vo/pMmMuBE88+qcNQvf6tL4FQA/gZ0jVp3A0fnw/UL7iqF8mffzE2ZQwS+l7Q==
+"@frontegg/js@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.121.0.tgz#6f689b5e593e1a5af429f31ebac7cc160056ee3f"
+  integrity sha512-1b3iatasy2KmjxQb1MBeVu2YDt1rDOyfZU1XOGhpILNVCPBAx0ikR1FpilaeAIeDfnWUzmCW5djO2Vf39LPAFQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.120.0"
+    "@frontegg/types" "7.121.0"
 
-"@frontegg/redux-store@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.120.0.tgz#cae4c1fb5bf8aac985d5ef6dbcac5a9bdb214c7b"
-  integrity sha512-kv8TiCYmPe9TZPGnXAa88sEIYYc2CfKBSylxiZH3vayezRxfdYb8vwJOMX/+z8zoEVnW/2PvfzAHNLB5vmsCWQ==
+"@frontegg/redux-store@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.121.0.tgz#5b7c5ffebb72c6bafc82e66eec84489313d125e8"
+  integrity sha512-veuogq/+FytB4QJrLaXGmoGKK8qXAlbYwEP8YEN6F3pk3IRlOSw6IUcgfJjUBBCnteWd7RSsUaN53F+EBOPdSg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.120.0"
+    "@frontegg/rest-api" "7.121.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.120.0.tgz#1cc000520dc430d84c96650a6bc7c7a522976ceb"
-  integrity sha512-EXOdZZmhs5HzwerInobCBfb/fPLdcjXyTJRqjT9WebDy8yYNanWeYWCXVVqgKWmQk0sfb0g6G80tY5QVUqAa+A==
+"@frontegg/rest-api@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.121.0.tgz#d1cd44a73d3e7383933e36679b8ce58ea09d9e70"
+  integrity sha512-0hyqdFocy7nToQSIOpZXycSesQQeudAhHzJE16Qh529iVYfAQkhhagbyH397OtwsEHsQ7GUlOrq7SEe+GrDP9w==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.120.0":
-  version "7.120.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.120.0.tgz#64094156bf70054b2023f35f680c7af1a21bc0d5"
-  integrity sha512-+JFl7jGzFbDsTTxPMvj/AvifWDXfIu0k8A3NDt2JavbCz0MnkmtLxmZhF3YJkTUesWslGiPnj3qHy1mYO8R//A==
+"@frontegg/types@7.121.0":
+  version "7.121.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.121.0.tgz#e5d1fd00c4b2e2342a935417a075c8192bff35c9"
+  integrity sha512-uYswZ8MIZYXcB1anFdDucV+RQ4W5OCgUwuia85pbFWfnIz6iNxK3+++VSSYzd/m0UItMLtWhyUVyYpgbhshONA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.120.0"
+    "@frontegg/redux-store" "7.121.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,43 +1835,43 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.119.0.tgz#6b9df0f41390a9b2ac8ef3dbedc3d46fae8a3b80"
-  integrity sha512-U4A0Gz57G/trMHZpOf8tG94LLbsc0A+DbZmBJ4eMQFM+zS/4UKgc3k0V0QdeID3D4nPr8T+RuqqueOOHVlFBdg==
+"@frontegg/js@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.120.0.tgz#724392aeb510d3701ebaa6e17b882b2c681f35e0"
+  integrity sha512-He9hxIBNelS6V9NhuGYS84rH2Vo/pMmMuBE88+qcNQvf6tL4FQA/gZ0jVp3A0fnw/UL7iqF8mffzE2ZQwS+l7Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.119.0"
+    "@frontegg/types" "7.120.0"
 
-"@frontegg/redux-store@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.119.0.tgz#e932dab1cc046242ac70d81d5afe64f863aba045"
-  integrity sha512-TKdkfdqiV6x7IjmwNfhUEpmCYLuLLshR1bTdZdIaEMr+4PjTKnN+qIEX8Gb/Dy9eVJCHIC4/pFegQBK+s655Gg==
+"@frontegg/redux-store@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.120.0.tgz#cae4c1fb5bf8aac985d5ef6dbcac5a9bdb214c7b"
+  integrity sha512-kv8TiCYmPe9TZPGnXAa88sEIYYc2CfKBSylxiZH3vayezRxfdYb8vwJOMX/+z8zoEVnW/2PvfzAHNLB5vmsCWQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.119.0"
+    "@frontegg/rest-api" "7.120.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.119.0.tgz#2ab4e1a769ac9b1c08f25d09396140ac903a2a3d"
-  integrity sha512-Tm2fmbRGNHWJT4SAr0cKdOWxgqFPMx9RsMxpgNtkDiFEdAUrusoDYKogJsm9YVQcXFuJnYuBTNfpCClPXDx5jg==
+"@frontegg/rest-api@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.120.0.tgz#1cc000520dc430d84c96650a6bc7c7a522976ceb"
+  integrity sha512-EXOdZZmhs5HzwerInobCBfb/fPLdcjXyTJRqjT9WebDy8yYNanWeYWCXVVqgKWmQk0sfb0g6G80tY5QVUqAa+A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.119.0":
-  version "7.119.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.119.0.tgz#ec62cf7e13687ff25cab848f6c489ab0bd7fd863"
-  integrity sha512-hye2AFyd+X2svUNCYBc1WjnrnwXyQOtMfxOJpApEKlTy9uwrD0u1DcNxQE0iEzf3tYFosqeD46FOzsmhZeHeeg==
+"@frontegg/types@7.120.0":
+  version "7.120.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.120.0.tgz#64094156bf70054b2023f35f680c7af1a21bc0d5"
+  integrity sha512-+JFl7jGzFbDsTTxPMvj/AvifWDXfIu0k8A3NDt2JavbCz0MnkmtLxmZhF3YJkTUesWslGiPnj3qHy1mYO8R//A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.119.0"
+    "@frontegg/redux-store" "7.120.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-25731 - Fixed chooser load-error state seeding when switchable list empties after opening


- FR-25731 - Added post-auth Choose Organization step in login-box (forward-port of #2864 to v7.120.x)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Login and organization-selection flows come from the upgraded Frontegg SDK; risk is moderate because auth UX changes without local code review in this PR.
> 
> **Overview**
> Bumps the Vue package’s `@frontegg/js` dependency from **7.119.0** to **7.121.0** and refreshes `yarn.lock` so the linked `@frontegg/types`, `@frontegg/redux-store`, and `@frontegg/rest-api` packages align on **7.121.0**. There are no application source changes in this repo—consumers pick up upstream Admin Portal / login-box behavior from that release (e.g. post-auth **Choose Organization** and chooser load-error handling per FR-25731).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a4b821d0d7b2ee1fbb643ac4563cc912fe7842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->